### PR TITLE
初めましてメニューの表示条件変更

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/announcements.jsx
+++ b/app/assets/javascripts/components/features/compose/components/announcements.jsx
@@ -15,7 +15,7 @@ const hashtags = Immutable.fromJS([
 ]);
 
 const mapStateToProps = state => ({
-  isEmptyHome: state.getIn(['timelines', 'home', 'items']).size == 0
+  isEmptyHome: state.getIn(['timelines', 'home', 'items']).size < 5
 });
 
 const Announcements = React.createClass({


### PR DESCRIPTION
前回のPR #5 だと、条件がホームが空の時なため
テストでトゥートすると表示が消えてしまいます。

このPRを採用するとホームが5未満だと表示されるようになりますので、
必要に応じてマージをご検討下さい。