### PR TITLE
change default database name to imastodon from mastodon

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ source /home/vagrant/.rvm/scripts/rvm
 
 # Configure database
 sudo -u postgres createuser -U postgres vagrant -s
-sudo -u postgres createdb -U postgres mastodon_development
+sudo -u postgres createdb -U postgres imastodon_development
 
 # Install gems and node modules
 gem install bundler

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,19 +6,19 @@ default: &default
 
 development:
   <<: *default
-  database: mastodon_development
+  database: imastodon_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: mastodon_test
+  database: imastodon_test
 
 production:
   <<: *default
-  database: <%= ENV['DB_NAME'] || 'mastodon_production' %>
-  username: <%= ENV['DB_USER'] || 'mastodon' %>
+  database: <%= ENV['DB_NAME'] || 'imastodon_production' %>
+  username: <%= ENV['DB_USER'] || 'imastodon' %>
   password: <%= ENV['DB_PASS'] || '' %>
   host: <%= ENV['DB_HOST'] || 'localhost' %>
   port: <%= ENV['DB_PORT'] || 5432 %>

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -35,15 +35,15 @@ if (cluster.isMaster) {
 
   const pgConfigs = {
     development: {
-      database: 'mastodon_development',
+      database: 'imastodon_development',
       host:     '/var/run/postgresql',
       max:      10
     },
 
     production: {
-      user:     process.env.DB_USER || 'mastodon',
+      user:     process.env.DB_USER || 'imastodon',
       password: process.env.DB_PASS || '',
-      database: process.env.DB_NAME || 'mastodon_production',
+      database: process.env.DB_NAME || 'imastodon_production',
       host:     process.env.DB_HOST || 'localhost',
       port:     process.env.DB_PORT || 5432,
       max:      10


### PR DESCRIPTION
本家マストドンとアイマストドンの開発を別々に行う際、
ベースとしているバージョンの違いからdev環境のDBを分ける必要がありましたので変更しました