### PR TITLE
管理者メッセージ欄追加

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/admin_announcements.jsx
+++ b/app/assets/javascripts/components/features/compose/components/admin_announcements.jsx
@@ -1,0 +1,32 @@
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+const mapStateToProps = state => ({
+  settings: state.getIn(['meta', 'admin_announcement'])
+});
+
+
+const AdminAnnouncements = React.createClass({
+  render () {
+    const { settings } = this.props;
+
+    if (settings.length == 0) {
+      return null;
+    }
+    return (
+      <ul className='announcements'>
+        <li>
+          <div className='announcements__admin'>
+            <p dangerouslySetInnerHTML={{__html: settings}}></p>
+          </div>
+        </li>
+      </ul>
+    );
+  }
+});
+
+AdminAnnouncements.propTypes = {
+  settings: PropTypes.string
+};
+
+export default connect(mapStateToProps)(AdminAnnouncements);

--- a/app/assets/javascripts/components/features/compose/index.jsx
+++ b/app/assets/javascripts/components/features/compose/index.jsx
@@ -10,6 +10,7 @@ import SearchContainer from './containers/search_container';
 import { Motion, spring } from 'react-motion';
 import SearchResultsContainer from './containers/search_results_container';
 import Announcements from './components/announcements';
+import AdminAnnouncements from './components/admin_announcements';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -58,6 +59,7 @@ class Compose extends React.PureComponent {
 
         <div className='drawer__pager'>
           <div className='drawer__inner'>
+            <AdminAnnouncements />
             <NavigationContainer />
             <ComposeFormContainer />
             <Announcements />

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2577,6 +2577,16 @@ button.icon-button.active i.fa-retweet {
   }
 }
 
+.announcements__admin {
+  width: 100%;
+  position: relative;
+
+  p {
+    padding: 0 5px;
+    font-size: 14px;
+  }
+}
+
 .announcements__icon {
   display: inline-block;
   position: absolute;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,6 +9,7 @@ class HomeController < ApplicationController
     @web_settings           = Web::Setting.find_by(user: current_user)&.data || {}
     @admin                  = Account.find_local(Setting.site_contact_username)
     @streaming_api_base_url = Rails.configuration.x.streaming_api_base_url
+    @admin_announcement     = Setting.find_by(var: 'admin_announcement')&.value || ''
   end
 
   private

--- a/app/views/admin/settings/index.html.haml
+++ b/app/views/admin/settings/index.html.haml
@@ -38,3 +38,8 @@
         %strong= t('admin.settings.registrations.closed_message.title')
         %p= t('admin.settings.registrations.closed_message.desc_html')
       %td= best_in_place @settings['closed_registrations_message'], :value, as: :textarea, url: admin_setting_path(@settings['closed_registrations_message'])
+    %tr
+      %td
+        %strong= t('admin.settings.admin_announcement.title')
+        %p= t('admin.settings.admin_announcement.desc_html')
+      %td= best_in_place @settings['admin_announcement'], :value, as: :textarea, url: admin_setting_path(@settings['admin_announcement'])

--- a/app/views/home/initial_state.json.rabl
+++ b/app/views/home/initial_state.json.rabl
@@ -10,6 +10,7 @@ node(:meta) do
     admin: @admin.try(:id),
     boost_modal: current_account.user.setting_boost_modal,
     auto_play_gif: current_account.user.setting_auto_play_gif,
+    admin_announcement: @admin_announcement,
   }
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,9 @@ en:
       unresolved: Unresolved
       view: View
     settings:
+      admin_announcement:
+        desc_html: Displayed on frontpage.<br>You can use HTML tags
+        title: Administrator announcement
       click_to_edit: Click to edit
       contact_information:
         email: Enter a public e-mail address

--- a/config/locales/ja-IM.yml
+++ b/config/locales/ja-IM.yml
@@ -157,6 +157,9 @@ ja-IM:
       unresolved: 未解決
       view: 表示
     settings:
+      admin_announcement:
+        desc_html: トップページの投稿メニューの上に管理者メッセージが表示されます。<br>HTMLタグが利用可能です。
+        title: 管理者からのメッセージ
       click_to_edit: クリックして編集
       contact_information:
         email: 公開するメールアドレスを入力

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -157,6 +157,9 @@ ja:
       unresolved: 未解決
       view: 表示
     settings:
+      admin_announcement:
+        desc_html: トップページの投稿メニューの上に管理者メッセージが表示されます。<br>HTMLタグが利用可能です。
+        title: 管理者からのメッセージ
       click_to_edit: クリックして編集
       contact_information:
         email: 公開するメールアドレスを入力

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,6 +14,7 @@ defaults: &defaults
   site_contact_email: ''
   open_registrations: true
   closed_registrations_message: ''
+  admin_announcement: ''
   boost_modal: false
   auto_play_gif: true
   notification_emails:


### PR DESCRIPTION
管理画面の設定項目に管理者メッセージを追加し、
入力がある時は投稿欄の上に表示するようにします。

- 管理画面
![03](https://cloud.githubusercontent.com/assets/11332152/26761838/c9b18cae-4971-11e7-82bd-0a2baae55ad4.jpg)

- 投稿欄 off

![02](https://cloud.githubusercontent.com/assets/11332152/26761843/dd608854-4971-11e7-950e-68fe5e9940f6.jpg)

- 投稿欄 on

![04](https://cloud.githubusercontent.com/assets/11332152/26761845/e16a303a-4971-11e7-8427-b132031465a0.jpg)
