### PR TITLE
Make the announcement box collapsible

### DIFF
--- a/app/javascript/mastodon/components/announcement_icon_button.js
+++ b/app/javascript/mastodon/components/announcement_icon_button.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import Motion from 'react-motion/lib/Motion';
+import spring from 'react-motion/lib/spring';
+import PropTypes from 'prop-types';
+
+class IconButton extends React.PureComponent {
+
+  static propTypes = {
+    className: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    icon: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+    size: PropTypes.number,
+    active: PropTypes.bool,
+    style: PropTypes.object,
+    activeStyle: PropTypes.object,
+    disabled: PropTypes.bool,
+    inverted: PropTypes.bool,
+    animate: PropTypes.bool,
+    overlay: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    size: 18,
+    active: false,
+    disabled: false,
+    animate: false,
+    overlay: false,
+  };
+
+  handleClick = (e) =>  {
+    e.preventDefault();
+
+    if (!this.props.disabled) {
+      this.props.onClick(e);
+    }
+  }
+
+  render () {
+    const style = {
+      fontSize: `${this.props.size}px`,
+      width: `${this.props.size * 1.28571429}px`,
+      height: `${this.props.size * 1.28571429}px`,
+      lineHeight: `${this.props.size}px`,
+      ...this.props.style,
+      ...(this.props.active ? this.props.activeStyle : {}),
+    };
+
+    const classes = ['icon-button'];
+
+    if (this.props.active) {
+      classes.push('active');
+    }
+
+    if (this.props.disabled) {
+      classes.push('disabled');
+    }
+
+    if (this.props.inverted) {
+      classes.push('inverted');
+    }
+
+    if (this.props.overlay) {
+      classes.push('overlayed');
+    }
+
+    if (this.props.className) {
+      classes.push(this.props.className);
+    }
+
+    return (
+      <Motion defaultStyle={{ rotate: this.props.active ? 180 : 0 }} style={{ rotate: this.props.animate ? spring(this.props.active ? 0 : 180) : 0 }}>
+        {({ rotate }) =>
+          <button
+            aria-label={this.props.title}
+            title={this.props.title}
+            className={classes.join(' ')}
+            onClick={this.handleClick}
+            style={style}>
+            <i style={{ transform: `rotate(${rotate}deg)` }} className={`fa fa-fw fa-${this.props.icon}`} aria-hidden='true' />
+          </button>
+        }
+      </Motion>
+    );
+  }
+
+}
+
+export default IconButton;

--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -4,7 +4,26 @@ import Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import Link from 'react-router/lib/Link';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import IconButton from '../../../components/icon_button';
+import IconButton from '../../../components/announcement_icon_button';
+import Motion from 'react-motion/lib/Motion';
+import spring from 'react-motion/lib/spring';
+
+const Collapsable = ({ fullHeight, minHeight, isVisible, children }) => (
+  <Motion defaultStyle={{height: isVisible ? fullHeight : minHeight }} style={{height: spring(!isVisible ? minHeight : fullHeight) }}>
+    {({ height }) =>
+      <div style={{ height: `${height}px`, overflow: 'hidden'}}>
+        {children}
+      </div>
+    }
+  </Motion>
+);
+
+Collapsable.propTypes = {
+  fullHeight: PropTypes.number.isRequired,
+  minHeight: PropTypes.number.isRequired,
+  isVisible: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 const messages = defineMessages({
   welcome: { id: 'welcome.message', defaultMessage: 'Welcome to {domain}!' },
@@ -28,6 +47,7 @@ class Announcements extends React.PureComponent {
 
   state = {
     show: true,
+    first: true,
   };
 
   onClick = () => {
@@ -45,24 +65,27 @@ class Announcements extends React.PureComponent {
 
   render () {
     const { intl, isEmptyHome } = this.props;
-    const { show } = this.state;
 
-    if (!isEmptyHome) {
-      return null;
+    if(this.state.first && !isEmptyHome) {
+      this.state.first = false;
+      this.state.show = false;
     }
+
     return (
       <ul className='announcements'>
-        <li style={{display: show ? '' : 'none'}}>
-          <div className='announcements__body'>
-            <p>{this.nl2br(intl.formatMessage(messages.welcome, {domain: document.title}))}</p>
-            {hashtags.map(hashtag =>
-              <Link to={`/timelines/tag/${hashtag}`}>
-                #{hashtag}
-              </Link>
-            )}
-          </div>
+        <li>
+          <Collapsable isVisible={this.state.show} fullHeight={300} minHeight={20} >
+            <div className='announcements__body'>
+              <p>{this.nl2br(intl.formatMessage(messages.welcome, {domain: document.title}))}</p>
+              {hashtags.map(hashtag =>
+                <Link to={`/timelines/tag/${hashtag}`}>
+                  #{hashtag}
+                </Link>
+              )}
+            </div>
+          </Collapsable>
           <div className='announcements__icon'>
-            <IconButton icon='times' onClick={this.onClick} size={16} />
+            <IconButton icon='caret-up' onClick={this.onClick} size={20} animate={true} active={this.state.show} />
           </div>
         </li>
       </ul>

--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import Immutable from 'immutable';
 import PropTypes from 'prop-types';
 import Link from 'react-router/lib/Link';
@@ -34,25 +33,20 @@ const hashtags = Immutable.fromJS([
   'みんなのP名刺',
 ]);
 
-const mapStateToProps = state => ({
-  isEmptyHome: state.getIn(['timelines', 'home', 'items']).size < 5,
-});
-
 class Announcements extends React.PureComponent {
 
   static propTypes = {
     intl: PropTypes.object.isRequired,
-    isEmptyHome: PropTypes.bool,
+    homeSize: PropTypes.number,
+    isLoading: PropTypes.bool,
   };
 
   state = {
-    show: true,
-    first: true,
+    show: false,
   };
 
   onClick = () => {
-    const currentShow = this.state.show;
-    this.setState({show: !currentShow});
+    this.setState({show: !this.state.show});
   }
   nl2br (text) {
     return text.split(/(\n)/g).map(function (line) {
@@ -64,12 +58,7 @@ class Announcements extends React.PureComponent {
   }
 
   render () {
-    const { intl, isEmptyHome } = this.props;
-
-    if(this.state.first && !isEmptyHome) {
-      this.state.first = false;
-      this.state.show = false;
-    }
+    const { intl } = this.props;
 
     return (
       <ul className='announcements'>
@@ -92,6 +81,12 @@ class Announcements extends React.PureComponent {
     );
   }
 
+  componentWillReceiveProps (nextProps) {
+    if (!nextProps.isLoading && (nextProps.homeSize === 0 || this.props.homeSize !== nextProps.homeSize)) {
+        this.setState({show: nextProps.homeSize < 5});
+    }
+  }
+
 }
 
-export default connect(mapStateToProps)(injectIntl(Announcements));
+export default injectIntl(Announcements);

--- a/app/javascript/mastodon/features/compose/containers/announcements_container.js
+++ b/app/javascript/mastodon/features/compose/containers/announcements_container.js
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux';
+import Announcements from '../components/announcements';
+
+const mapStateToProps = (state, props) => {
+  return {
+    homeSize: state.getIn(['timelines', 'home', 'items']).size,
+    isLoading: state.getIn(['timelines', 'home', 'isLoading']),
+  };
+};
+
+export default connect(mapStateToProps)(Announcements);

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -11,7 +11,7 @@ import SearchContainer from './containers/search_container';
 import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
-import Announcements from './components/announcements';
+import AnnouncementsContainer from './containers/announcements_container';
 import AdminAnnouncements from './components/admin_announcements';
 
 const messages = defineMessages({
@@ -71,7 +71,7 @@ class Compose extends React.PureComponent {
             <AdminAnnouncements />
             <NavigationContainer />
             <ComposeFormContainer />
-            <Announcements />
+            <AnnouncementsContainer />
           </div>
 
           <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2808,7 +2808,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .announcements {
-  padding: 10px;
+  padding: 5px;
 
   li {
     display: flex;


### PR DESCRIPTION
This change makes the announcement box collapsible.
![collapsible_announcement](https://user-images.githubusercontent.com/8458066/27164721-1d896c10-51ca-11e7-8814-65a1f774aa10.gif)
After loading, it is shown in the expanded state if less than 5 toots are shown in the home timeline. Otherwise, it is shown in the collapsed state.