### PR TITLE
API /api/v1/instance に管理者メッセージ追加

### DIFF
--- a/app/javascript/mastodon/features/compose/components/admin_announcements.js
+++ b/app/javascript/mastodon/features/compose/components/admin_announcements.js
@@ -1,11 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
-const mapStateToProps = state => ({
-  settings: state.getIn(['meta', 'admin_announcement']),
-});
-
 
 class AdminAnnouncements extends React.PureComponent {
 
@@ -32,4 +26,4 @@ class AdminAnnouncements extends React.PureComponent {
 
 }
 
-export default connect(mapStateToProps)(AdminAnnouncements);
+export default AdminAnnouncements;

--- a/app/javascript/mastodon/features/compose/containers/admin_announcements_container.js
+++ b/app/javascript/mastodon/features/compose/containers/admin_announcements_container.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import AdminAnnouncements from '../components/admin_announcements';
+
+const mapStateToProps = (state, props) => {
+  return {
+    settings: state.getIn(['meta', 'admin_announcement']),
+  };
+};
+
+export default connect(mapStateToProps)(AdminAnnouncements);

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -12,7 +12,7 @@ import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
 import Announcements from './components/announcements';
-import AdminAnnouncements from './components/admin_announcements';
+import AdminAnnouncementsContainer from './containers/admin_announcements_container';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -68,7 +68,7 @@ class Compose extends React.PureComponent {
 
         <div className='drawer__pager'>
           <div className='drawer__inner'>
-            <AdminAnnouncements />
+            <AdminAnnouncementsContainer />
             <NavigationContainer />
             <ComposeFormContainer />
             <Announcements />

--- a/app/views/api/v1/instances/show.rabl
+++ b/app/views/api/v1/instances/show.rabl
@@ -1,7 +1,8 @@
 object false
 
-node(:uri)         { site_hostname }
-node(:title)       { Setting.site_title }
-node(:description) { Setting.site_description }
-node(:email)       { Setting.site_contact_email }
-node(:version)     { Mastodon::Version.to_s }
+node(:uri)          { site_hostname }
+node(:title)        { Setting.site_title }
+node(:description)  { Setting.site_description }
+node(:announcement) { Setting.admin_announcement }
+node(:email)        { Setting.site_contact_email }
+node(:version)      { Mastodon::Version.to_s }


### PR DESCRIPTION
instance情報を取得するAPIに、
管理者メッセージ(admin_annoucements)を追加しました。
(そしてReact部分のコードのリファクタリングもしました)

修正後は下記のようになります。

### Instance

| Attribute                | Description                                                              | Nullable |
| ------------------------ | ------------------------------------------------------------------------ | -------- |
| `uri`                    | URI of the current instance                                              | no       |
| `title`                  | The instance's title                                                     | no       |
| `description`            | A description for the instance                                           | no       |
| `announcement`            | An announcement from addministrator for the instance                                           | no       |
| `email`                  | An email address which can be used to contact the instance administrator | no       |
| `version`                | The Mastodon version used by instance.                                   | no       |


ドキュメントは本家の方しかなかったので直していません。
https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#instance