### PR TITLE
fix Announcements component has some warning on React

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -25,6 +25,7 @@ Collapsable.propTypes = {
 };
 
 const messages = defineMessages({
+  toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
   welcome: { id: 'welcome.message', defaultMessage: 'Welcome to {domain}!' },
 });
 
@@ -49,9 +50,11 @@ class Announcements extends React.PureComponent {
     this.setState({ show: !this.state.show });
   }
   nl2br (text) {
-    return text.split(/(\n)/g).map(function (line) {
+    return text.split(/(\n)/g).map((line, i) => {
       if (line.match(/(\n)/g)) {
-        return React.createElement('br');
+        return (
+          <br key={i} />
+        );
       }
       return line;
     });
@@ -66,15 +69,15 @@ class Announcements extends React.PureComponent {
           <Collapsable isVisible={this.state.show} fullHeight={300} minHeight={20} >
             <div className='announcements__body'>
               <p>{ this.nl2br(intl.formatMessage(messages.welcome, { domain: document.title }))}</p>
-              {hashtags.map(hashtag =>
-                <Link to={`/timelines/tag/${hashtag}`}>
+              {hashtags.map((hashtag, i) =>
+                <Link key={i} to={`/timelines/tag/${hashtag}`}>
                   #{hashtag}
                 </Link>
               )}
             </div>
           </Collapsable>
           <div className='announcements__icon'>
-            <IconButton icon='caret-up' onClick={this.onClick} size={20} animate active={this.state.show} />
+            <IconButton title={intl.formatMessage(messages.toggle_visible)} icon='caret-up' onClick={this.onClick} size={20} animate active={this.state.show} />
           </div>
         </li>
       </ul>

--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -52,9 +52,7 @@ class Announcements extends React.PureComponent {
   nl2br (text) {
     return text.split(/(\n)/g).map((line, i) => {
       if (line.match(/(\n)/g)) {
-        return (
-          <br key={i} />
-        );
+        return React.createElement('br', { key: i });
       }
       return line;
     });


### PR DESCRIPTION
related #13 

だいたいは #13 に書いてある https://github.com/fvh-P/mastodon/commit/3fa862e1b2abe1f7d8da609a182b73fd5627edc8 をベースにしてます。

IconButtonのtitle属性に使うI18nメッセージは本来であれば専用のものを用意すべきなんだろうと思われますが、
全く同じ用途のものが重複してしまって面倒くさくなりそうだったのでmedia_galleryのものをそのまま拝借しました