### PR TITLE
change make_able_to_manualy_folding_announcements

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -44,6 +44,7 @@ class Announcements extends React.PureComponent {
 
   state = {
     show: false,
+    isLoaded: false,
   };
 
   onClick = () => {
@@ -83,8 +84,10 @@ class Announcements extends React.PureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (!nextProps.isLoading && (nextProps.homeSize === 0 || this.props.homeSize !== nextProps.homeSize)) {
-      this.setState({ show: nextProps.homeSize < 5 });
+    if (!this.state.isLoaded) {
+      if (!nextProps.isLoading && (nextProps.homeSize === 0 || this.props.homeSize !== nextProps.homeSize)) {
+        this.setState({ show: nextProps.homeSize < 5, isLoaded: true });
+      }
     }
   }
 


### PR DESCRIPTION
announcementsコンポーネントを手動で開いた後にホームタイムラインが更新された場合、
ホームタイムラインの件数による条件判定が再度行われて勝手に畳まれてしまうという事象がありました。

対応として、stateにisAutoを追加しました。
onClickのハンドル時にshowを反転させると同時にisAutoにfalseをセットし、
ホームタイムラインの件数による条件判定時にisAutoも参照することで、
一度手動で開閉した後は勝手に畳まれないように変更しました。