### PR TITLE
Converting images

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -68,7 +68,8 @@ class MediaAttachment < ApplicationRecord
   end
 
   before_create :set_shortcode
-  before_post_process :set_type_and_extension
+  before_post_process :set_type
+  after_post_process :set_extension
   before_save :set_meta
 
   class << self
@@ -104,6 +105,8 @@ class MediaAttachment < ApplicationRecord
     def file_processors(f)
       if f.file_content_type == 'image/gif'
         [:gif_transcoder]
+      elsif IMAGE_MIME_TYPES.include? f.file_content_type
+        [:img_converter, :thumbnail]
       elsif VIDEO_MIME_TYPES.include? f.file_content_type
         [:video_transcoder]
       else
@@ -125,8 +128,11 @@ class MediaAttachment < ApplicationRecord
     end
   end
 
-  def set_type_and_extension
+  def set_type
     self.type = VIDEO_MIME_TYPES.include?(file_content_type) ? :video : :image
+  end
+
+  def set_extension
     extension = appropriate_extension
     basename  = Paperclip::Interpolations.basename(file, :original)
     file.instance_write :file_name, [basename, extension].delete_if(&:blank?).join('.')

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -3,7 +3,6 @@
 Paperclip.options[:read_timeout] = 60
 
 Paperclip.interpolates :filename do |attachment, style|
-  return attachment.original_filename if style == :original
   [basename(attachment, style), extension(attachment, style)].delete_if(&:blank?).join('.')
 end
 

--- a/lib/paperclip/img_converter.rb
+++ b/lib/paperclip/img_converter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Paperclip
+  # This transcoder is only to be used for the MediaAttachment model
+  # to convert images to JPG (except for transparent PNG)
+  class ImgConverter < Processor
+    def make
+      if identify('-format "%[opaque]" :src', src: File.expand_path(file.path)) == 'true'
+        basename = File.basename(file.path, File.extname(file.path))
+        dst_name = basename << ".jpg"
+
+        dst = Paperclip::TempfileFactory.new.generate(dst_name)
+
+        convert(':src :dst',
+                src: File.expand_path(file.path),
+                dst: File.expand_path(dst.path))
+
+        src_filesize = identify('-format %b :src', src: File.expand_path(file.path)).to_i
+        dst_filesize = identify('-format %b :dst', dst: File.expand_path(dst.path)).to_i
+        if src_filesize > dst_filesize
+          attachment.instance.file_content_type = 'image/jpeg'
+          return dst
+        end
+      end
+      tmp_file = Paperclip::TempfileFactory.new.generate(attachment.instance.file_file_name)
+      tmp_file << file.read
+    end
+  end
+end


### PR DESCRIPTION
Converting images to JPG file except for PNG files with transparency.
If the file size of converted one is smaller than original one, the image is saved as converted format. Otherwise, it is saved as original format.