### PR TITLE
Enable to show unlisted tagged toots on the hashtag timeline

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -141,7 +141,8 @@ class Status < ApplicationRecord
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      query = timeline_scope(local_only).tagged_with(tag)
+      where(visibility: [:public, :unlisted])
+      query = timeline_scope(local_only, false).tagged_with(tag)
 
       apply_timeline_filters(query, account, local_only)
     end
@@ -200,11 +201,13 @@ class Status < ApplicationRecord
 
     private
 
-    def timeline_scope(local_only = false)
+    def timeline_scope(local_only = false, public_only = true)
       starting_scope = local_only ? Status.local_only : Status
-      starting_scope
-        .with_public_visibility
-        .without_reblogs
+
+      if public_only
+        starting_scope = starting_scope.with_public_visibility
+      end
+      starting_scope.without_reblogs
     end
 
     def apply_timeline_filters(query, account, local_only)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -21,7 +21,7 @@ class FanOutOnWriteService < BaseService
     render_anonymous_payload(status)
     deliver_to_hashtags(status)
 
-    return if status.reply? && status.in_reply_to_account_id != status.account_id
+    return if status.reply? && status.in_reply_to_account_id != status.account_id || status.unlisted_visibility?
 
     deliver_to_public(status)
   end

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -16,7 +16,7 @@ class FanOutOnWriteService < BaseService
       deliver_to_followers(status)
     end
 
-    return if status.account.silenced? || !status.public_visibility? || status.reblog?
+    return if status.account.silenced? || !status.public_visibility? && !status.unlisted_visibility? || status.reblog?
 
     render_anonymous_payload(status)
     deliver_to_hashtags(status)


### PR DESCRIPTION
Based on #29 

Currently, only "public" toots with hashtags are flowing to the hashtag timeline (/api/v1/streaming/hashtag), but this modifying enables to flow "unlisted" toots to the hash tag timeline.

現在、ハッシュタグ付きのトゥートについてはpublicなもののみがハッシュタグタイムライン(/api/v1/streaming/hashtag)に流れていますが、unlistedなトゥートでもハッシュタグタイムラインに流れるようにします。
