### PR TITLE
お気に入りタグ機能のロケール対応

### DIFF
--- a/app/javascript/mastodon/features/compose/components/favourite_tags.js
+++ b/app/javascript/mastodon/features/compose/components/favourite_tags.js
@@ -2,10 +2,17 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Link from 'react-router-dom/Link';
 import PropTypes from 'prop-types';
+import { injectIntl, defineMessages } from 'react-intl';
 
+const messages = defineMessages({
+  favourite_tags: { id: 'compose_form.favourite_tags', defaultMessage: 'Favourite tags' },
+});
+
+@injectIntl
 class FavouriteTags extends React.PureComponent {
 
   static propTypes = {
+    intl: PropTypes.object.isRequired,
     tags: ImmutablePropTypes.list.isRequired,
     locktag: PropTypes.string.isRequired,
     refreshFavouriteTags: PropTypes.func.isRequired,
@@ -29,6 +36,8 @@ class FavouriteTags extends React.PureComponent {
   }
 
   render () {
+    const { intl } = this.props;
+
     const tags = this.props.tags.map(tag => (
       <li key={tag.get('name')}>
         <Link
@@ -51,7 +60,7 @@ class FavouriteTags extends React.PureComponent {
       <div className='favourite-tags'>
         <div className='favourite-tags__header'>
           <i className='fa fa-tag' />
-          <div className='favourite-tags__header__name'>お気に入りタグ</div>
+          <div className='favourite-tags__header__name'>{intl.formatMessage(messages.favourite_tags)}</div>
           <div className='favourite-tags__lock'>
             <a href='/settings/favourite_tags'>
               <i className='fa fa-gear' />

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -551,6 +551,15 @@
   {
     "descriptors": [
       {
+        "defaultMessage": "Favourite tags",
+        "id": "compose_form.favourite_tags"
+      }
+    ],
+    "path": "app/javascript/mastodon/features/compose/components/favourite_tags.json"
+  },
+  {
+    "descriptors": [
+      {
         "defaultMessage": "Edit profile",
         "id": "navigation_bar.edit_profile"
       }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -52,6 +52,7 @@
   "compose_form.sensitive": "Mark media as sensitive",
   "compose_form.spoiler": "Hide text behind warning",
   "compose_form.spoiler_placeholder": "Write your warning here",
+  "compose_form.favourite_tags": "Favourite tags",
   "confirmation_modal.cancel": "Cancel",
   "confirmations.block.confirm": "Block",
   "confirmations.block.message": "Are you sure you want to block {name}?",

--- a/app/javascript/mastodon/locales/ja-IM.json
+++ b/app/javascript/mastodon/locales/ja-IM.json
@@ -52,6 +52,7 @@
   "compose_form.sensitive": "早苗さんに見つからないようにする",
   "compose_form.spoiler": "テキストを隠す",
   "compose_form.spoiler_placeholder": "ζ'ヮ')ζ＜まえせつ",
+  "compose_form.favourite_tags": "スウィーティー☆なタグ",
   "confirmation_modal.cancel": "キャンセル",
   "confirmations.block.confirm": "ブロック",
   "confirmations.block.message": "本当に{name}をブロックしますか？",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -52,6 +52,7 @@
   "compose_form.sensitive": "メディアを閲覧注意としてマークする",
   "compose_form.spoiler": "テキストを隠す",
   "compose_form.spoiler_placeholder": "ここに警告を書いてください",
+  "compose_form.favourite_tags": "お気に入りタグ",
   "confirmation_modal.cancel": "キャンセル",
   "confirmations.block.confirm": "ブロック",
   "confirmations.block.message": "本当に{name}をブロックしますか？",

--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -1,10 +1,10 @@
 - content_for :page_title do
-  お気に入りタグ
+  = t('settings.favourite_tags')
 
 = simple_form_for @favourite_tag, url: settings_favourite_tags_url do |f|
   = render 'shared/error_messages', object: @favourite_tag
   = f.simple_fields_for :tag do |ff|
-    = ff.input :name, placeholder: 'タグ名'
+    = ff.input :name, placeholder: t('favourite_tags.name_of_tag')
   = f.button :button, type: 'submit'
 %hr
 
@@ -19,4 +19,4 @@
           = form_for fav_tag, url: settings_favourite_tag_url(fav_tag), method: :delete do |f|
             = f.button :button, type: :submit, class: :negative do
               = fa_icon('times')
-              削除
+              = t('favourite_tags.delete')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -419,6 +419,10 @@ en:
     preferences: Preferences
     settings: Settings
     two_factor_authentication: Two-factor Authentication
+    favourite_tags: Favourite tags
+  favourite_tags:
+    name_of_tag: Name of tag
+    delete: delete
   statuses:
     open_in_web: Open in web
     over_character_limit: character limit of %{max} exceeded

--- a/config/locales/ja-IM.yml
+++ b/config/locales/ja-IM.yml
@@ -417,6 +417,10 @@ ja-IM:
     preferences: ユーザー設定
     settings: 設定
     two_factor_authentication: 二段階認証
+    favourite_tags: お気に入りタグ
+  favourite_tags:
+    name_of_tag: タグ名
+    delete: 削除
   statuses:
     open_in_web: Webで開く
     over_character_limit: 上限は %{max}文字までです

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -417,6 +417,10 @@ ja:
     preferences: ユーザー設定
     settings: 設定
     two_factor_authentication: 二段階認証
+    favourite_tags: お気に入りタグ
+  favourite_tags:
+    name_of_tag: タグ名
+    delete: 削除
   statuses:
     open_in_web: Webで開く
     over_character_limit: 上限は %{max}文字までです

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -13,7 +13,7 @@ SimpleNavigation::Configuration.run do |navigation|
       settings.item :export, safe_join([fa_icon('cloud-download fw'), t('settings.export')]), settings_export_url
       settings.item :authorized_apps, safe_join([fa_icon('list fw'), t('settings.authorized_apps')]), oauth_authorized_applications_url
       settings.item :follower_domains, safe_join([fa_icon('users fw'), t('settings.followers')]), settings_follower_domains_url
-      settings.item :favourite_tags, safe_join([fa_icon('tag'), 'お気に入りタグ']), settings_favourite_tags_url
+      settings.item :favourite_tags, safe_join([fa_icon('tag'), t('settings.favourite_tags')]), settings_favourite_tags_url
     end
 
     primary.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), admin_reports_url, if: proc { current_user.admin? } do |admin|


### PR DESCRIPTION
とりあえずja.ymlとen.ymlだけ(ja-IMは逆輸出のために別commitにするつもり

 - react-intlの繋ぎ込みがほかのところを参考にしたつもりなのにうまく動いていない
 - お気に入りタグ設定画面の追加ボタンのロケール対応方法がわからない
   - けどなぜかlocaleに合わせて変化している

わからんこ(画像略