### PR TITLE
update favourite_tags api don't use template

### DIFF
--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -8,5 +8,6 @@ class Api::V1::FavouriteTagsController < Api::BaseController
 
   def index
     @tags = current_account.favourite_tags.includes(:tag).map(&:tag)
+    render json: @tags
   end
 end

--- a/app/views/api/v1/favourite_tags/index.rabl
+++ b/app/views/api/v1/favourite_tags/index.rabl
@@ -1,2 +1,0 @@
-collection @tags
-attributes :name


### PR DESCRIPTION
v1.5になってAPIはSerializersを使用してテンプレートを使わない実装になっています。
それに合わせて、favourite_tagsのAPIもテンプレートを使用しない実装に
修正致しました。