### PR TITLE
phase1 お気に入りタグと公開設定連動

### DIFF
--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -8,5 +8,6 @@ class Api::V1::FavouriteTagsController < Api::BaseController
 
   def index
     @tags = current_account.favourite_tags.includes(:tag).map(&:tag)
+    render json: @tags
   end
 end

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -258,7 +258,8 @@ export default function compose(state = initialState, action) {
   case COMPOSE_EMOJI_INSERT:
     return insertEmoji(state, action.position, action.emoji);
   case COMPOSE_LOCK_TAG:
-    return setDefaultText(state, action.tag);
+    return setDefaultText(state, action.tag)
+      .set('privacy', action.tag != '' ? 'unlisted' : 'public');
   default:
     return state;
   }

--- a/app/views/api/v1/favourite_tags/index.rabl
+++ b/app/views/api/v1/favourite_tags/index.rabl
@@ -1,2 +1,0 @@
-collection @tags
-attributes :name


### PR DESCRIPTION
一旦、この段階でプルリクセストを送ります。
お気に入りタグをセットしたら強制的に未収載にするように修正致しました。
以後の開発で、タグと公開設定を紐付けた形にしますが
まずはこの形にしたいと思います。