### PR TITLE
縦幅が狭いときにお知らせを隠す

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3971,6 +3971,10 @@ noscript {
     }
   }
 
+  .announcements {
+    display: none;
+  }
+
   .is-composing {
     .tabs-bar,
     .search {


### PR DESCRIPTION
#38 の対応として、縦幅が狭いときにお知らせを全部隠すようにしてみました。