### PR TITLE
カラムヘッダーのアイコンがわかりにくいので歯車アイコンに変更する

### DIFF
--- a/app/javascript/mastodon/components/column_header.js
+++ b/app/javascript/mastodon/components/column_header.js
@@ -130,7 +130,7 @@ export default class ColumnHeader extends React.PureComponent {
     }
 
     if (children || multiColumn) {
-      collapseButton = <button className={collapsibleButtonClassName} aria-label={formatMessage(collapsed ? messages.show : messages.hide)} aria-pressed={collapsed ? 'false' : 'true'} onClick={this.handleToggleClick}><i className='fa fa-sliders' /></button>;
+      collapseButton = <button className={collapsibleButtonClassName} aria-label={formatMessage(collapsed ? messages.show : messages.hide)} aria-pressed={collapsed ? 'false' : 'true'} onClick={this.handleToggleClick}><i className='fa fa-gear' /></button>;
     }
 
     return (


### PR DESCRIPTION
イコライザー風のアイコンがわかりにくいので、歯車アイコンに変更する

![スクリーンショット](https://user-images.githubusercontent.com/206113/29423340-4f0b5bb8-83b6-11e7-9dd7-bc548f383378.png)
