### PR TITLE
add POST, PUT and DELETE method on api/v1/favourite_tags

### DIFF
--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Api::V1::FavouriteTagsController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read }
+
+  before_action :set_account
+  before_action -> { doorkeeper_authorize! :read }, only: [:index]
+  before_action -> { doorkeeper_authorize! :write }, except: [:index]
   before_action :require_user!
 
   respond_to :json
@@ -9,5 +12,29 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   def index
     @favourite_tags = current_account.favourite_tags.includes(:tag).map(&:to_json_for_api)
     render json: @favourite_tags
+  end
+  
+  def create
+    tag = find_tag
+    @favourite_tag = FavouriteTag.new(account: @account, tag: tag)
+    @favourite_tag.save
+    index
+  end
+  
+  def destroy
+    tag = find_tag
+    @favourite_tag = @account.favourite_tags.find_by(tag: tag)
+    @favourite_tag.destroy unless @favourite_tag.nil?
+    index
+  end
+
+  private
+
+  def set_account
+    @account = current_user.account
+  end
+
+  def find_tag
+    Tag.find_or_initialize_by(name: params[:tag])
   end
 end

--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -19,8 +19,11 @@ class Api::V1::FavouriteTagsController < Api::BaseController
     @favourite_tag = @account.favourite_tags.where(tag: tag).where.not(visibility: favourite_tag_visibility).first
     @favourite_tag.destroy unless @favourite_tag.nil?
     @favourite_tag = FavouriteTag.new(account: @account, tag: tag, visibility: favourite_tag_visibility)
-    @favourite_tag.save
-    index
+    if @favourite_tag.save
+      index
+    else
+      render json: current_account.favourite_tags.includes(:tag).map(&:to_json_for_api), status: :conflict
+    end
   end
 
   def destroy

--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -13,14 +13,16 @@ class Api::V1::FavouriteTagsController < Api::BaseController
     @favourite_tags = current_account.favourite_tags.includes(:tag).map(&:to_json_for_api)
     render json: @favourite_tags
   end
-  
+
   def create
     tag = find_tag
-    @favourite_tag = FavouriteTag.new(account: @account, tag: tag)
+    @favourite_tag = @account.favourite_tags.where(tag: tag).where.not(visibility: favourite_tag_visibility).first
+    @favourite_tag.destroy unless @favourite_tag.nil?
+    @favourite_tag = FavouriteTag.new(account: @account, tag: tag, visibility: favourite_tag_visibility)
     @favourite_tag.save
     index
   end
-  
+
   def destroy
     tag = find_tag
     @favourite_tag = @account.favourite_tags.find_by(tag: tag)
@@ -30,11 +32,19 @@ class Api::V1::FavouriteTagsController < Api::BaseController
 
   private
 
+  def tag_params
+    params.permit(:tag, :visibility)
+  end
+
   def set_account
     @account = current_user.account
   end
 
   def find_tag
-    Tag.find_or_initialize_by(name: params[:tag])
+    Tag.find_or_initialize_by(name: tag_params[:tag])
+  end
+
+  def favourite_tag_visibility
+    tag_params[:visibility].nil? ? 'public' : tag_params[:visibility]
   end
 end

--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -14,18 +14,18 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   end
 
   def create
-    tag = find_tag
+    tag = find_or_init_tag
     @favourite_tag = FavouriteTag.new(account: @account, tag: tag, visibility: favourite_tag_visibility)
     if @favourite_tag.save
       index
     else
-      render json: current_favourite_tags, status: :conflict
+      render json: find_fav_tag_by(tag).to_json_for_api, status: :conflict
     end
   end
 
   def update
-    tag = find_tag
-    @favourite_tag = @account.favourite_tags.find_by(tag: tag)
+    tag = find_or_init_tag
+    @favourite_tag = find_fav_tag_by(tag)
     if @favourite_tag.nil?
       render json: current_favourite_tags, status: :not_found
     else
@@ -40,8 +40,8 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   end
 
   def destroy
-    tag = find_tag
-    @favourite_tag = @account.favourite_tags.find_by(tag: tag)
+    tag = find_or_init_tag
+    @favourite_tag = find_fav_tag_by(tag)
     if @favourite_tag.nil?
       render json: current_favourite_tags, status: :not_found
     else
@@ -60,8 +60,12 @@ class Api::V1::FavouriteTagsController < Api::BaseController
     @account = current_user.account
   end
 
-  def find_tag
+  def find_or_init_tag
     Tag.find_or_initialize_by(name: tag_params[:tag])
+  end
+
+  def find_fav_tag_by(tag)
+    @account.favourite_tags.find_by(tag: tag)
   end
 
   def favourite_tag_visibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,7 +216,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :favourite_tags, only: [:index]
+      resources :favourite_tags, only: [:index, :create, :destroy], param: :tag
     end
 
     namespace :web do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,7 +216,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :favourite_tags, only: [:index, :create, :destroy], param: :tag
+      resources :favourite_tags, only: [:index, :create, :update, :destroy], param: :tag
     end
 
     namespace :web do

--- a/spec/controllers/api/v1/favourite_tags_controller_spec.rb
+++ b/spec/controllers/api/v1/favourite_tags_controller_spec.rb
@@ -40,8 +40,11 @@ RSpec.describe Api::V1::FavouriteTagsController, type: :controller do
       
       it 'does not create new favourite_tag and returns http 409' do
         expect {
-          post :create, params: { tag: tag_name, visibility: 'public' }
+          post :create, params: { tag: tag_name, visibility: 'private' }
         }.not_to change(FavouriteTag, :count)
+        expect(
+          JSON.parse(response.body, symbolize_names: true).except(:id)
+        ).to eq ({ name: tag_name, visibility: 'public' })
         expect(response).to have_http_status(:conflict)
       end
     end

--- a/spec/controllers/api/v1/favourite_tags_controller_spec.rb
+++ b/spec/controllers/api/v1/favourite_tags_controller_spec.rb
@@ -7,13 +7,75 @@ RSpec.describe Api::V1::FavouriteTagsController, type: :controller do
   let(:token) { double acceptable?: true, resource_owner_id: user.id }
 
   before do
-    Fabricate(:favourite_tag, account: user.account)
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
   describe 'GET #index' do
     it 'returns http success' do
       get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+  
+  describe 'POST #create' do
+    let(:tag_name) { 'dummy_tag' }
+    let!(:tag) { Fabricate(:tag, name: tag_name) }
+
+    it 'create the favourite tag' do
+      expect {
+        post :create, params: { tag: tag_name, visibility: 'public' }
+      }.to change(FavouriteTag, :count).by(1)
+      expect(JSON.parse(response.body, symbolize_names: true).map! {|item|
+        item.except(:id)
+      }).to eq ([{ :name => tag_name, :visibility => 'public' }])
+    end
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+
+    context 'when the tag has already been favourite.' do
+      before do
+        post :create, params: { tag: tag_name, visibility: 'public' }
+      end
+
+      context 'when the tag has the same visibility as already been favourite one.' do
+        before do
+          post :create, params: { tag: tag_name, visibility: 'public' }
+        end
+
+        it 'returns http 409' do
+          expect(response).to have_http_status(:conflict)
+        end
+      end
+
+      context 'when the tag has the different visibility as already been favourite one.' do
+        it 'should destroy the old one, create the new one and should render index template' do
+          expect {
+            post :create, params: { tag: tag_name, visibility: 'unlisted' }
+          }.not_to change(FavouriteTag, :count)
+          expect(JSON.parse(response.body, symbolize_names: true).map! {|item|
+            item.except(:id)
+          }).to eq ([{ :name => tag_name, :visibility => 'unlisted' }])
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
+      end
+    end
+  end
+  
+  describe 'DELETE #destroy' do
+    let!(:tag) { Fabricate(:tag, name: 'dummy_tag') }
+    let!(:favourite_tag) { Fabricate(:favourite_tag, account: user.account, tag: tag) }
+
+    it 'destroy the favourite tag' do
+      delete :destroy, params: { tag: favourite_tag.name }
+      expect(FavouriteTag.count).to eq 0
+    end
+
+    it 'returns http success' do
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
Add methods that process POST and DELETE request on api/v1/favourite_tags. It enables users to create and remove favourite tags through the API.

usage
+ `POST https://xxxxxx.yy/api/v1/favourite_tags?tag=test&access_token=??????????`
+ `DELETE https://xxxxxx.yy/api/v1/favourite_tags/test?access_token=??????????`

api/v1/favourite_tagsにPOSTとDELETEリクエストを処理するメソッドを追加します。API経由でお気に入りタグの追加・削除が可能になります。

- [x] POST・DELETE処理の実装
- [x] テストケース追加
- [x] #48 への追従