### PR TITLE
change default columns order

### DIFF
--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -56,8 +56,9 @@ const initialState = ImmutableMap({
 
 const defaultColumns = fromJS([
   { id: 'COMPOSE', uuid: uuid(), params: {} },
-  { id: 'HOME', uuid: uuid(), params: {} },
+  { id: 'COMMUNITY', uuid: uuid(), params: {} },
   { id: 'NOTIFICATIONS', uuid: uuid(), params: {} },
+  { id: 'HOME', uuid: uuid(), params: {} },
 ]);
 
 const hydrate = (state, settings) => state.mergeDeep(settings).update('columns', (val = defaultColumns) => val);


### PR DESCRIPTION
Add the community timeline to default columns and change its order.

デフォルトのカラムにLTLを追加した上で順序を変更します。
ホーム、通知、スタートの3つだったのが、LTL、通知、ホーム、スタートになります。
im@stodonの特性上新規ユーザにはデフォルトでLTLを見せておいた方がよいという判断です。
![2017-08-25](https://user-images.githubusercontent.com/8458066/29698306-7b5f0a0a-898f-11e7-9464-8f70377029e2.png)
