### PR TITLE
update favourite_tags components enable multiple selection

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/favourite_tags_container.js
+++ b/app/javascript/mastodon/features/compose/containers/favourite_tags_container.js
@@ -5,7 +5,6 @@ import { refreshFavouriteTags, lockTagCompose } from '../../../actions/favourite
 const mapStateToProps = state => {
   return {
     tags: state.getIn(['favourite_tags', 'tags']),
-    locktag: state.getIn(['compose', 'defaultText']),
   };
 };
 


### PR DESCRIPTION
お気に入りタグ複数選択の対応です。

実装の方向性としては、
components/favourite_tags.js 内で onLockTag メソッドに渡す値を
調整する感じで直しました。

resolve #50