### PR TITLE
各カラムのミュートキーワード入力欄の翻訳を修正

### DIFF
--- a/app/javascript/mastodon/locales/ja-IM.json
+++ b/app/javascript/mastodon/locales/ja-IM.json
@@ -90,7 +90,7 @@
   "getting_started.userguide": "ユーザーガイド",
   "home.column_settings.advanced": "MASTER",
   "home.column_settings.basic": "REGULAR",
-  "home.column_settings.filter_regex": "正規表現でフィルター",
+  "home.column_settings.filter_regex": "ミュートするキーワード(縦棒「|」区切り)",
   "home.column_settings.show_reblogs": "わかるわ表示",
   "home.column_settings.show_replies": "Reあふぅ表示",
   "home.settings": "カラム設定",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -90,7 +90,7 @@
   "getting_started.userguide": "ユーザーガイド",
   "home.column_settings.advanced": "上級者向け",
   "home.column_settings.basic": "基本設定",
-  "home.column_settings.filter_regex": "正規表現でフィルター",
+  "home.column_settings.filter_regex": "ミュートするキーワード(縦棒「|」区切り)",
   "home.column_settings.show_reblogs": "ブースト表示",
   "home.column_settings.show_replies": "返信表示",
   "home.settings": "カラム設定",


### PR DESCRIPTION
正規表現と書かれてもわからない方が多いと思ったので修正しました。

逆に、正規表現を自分で書ける程度に知っている人はわざわざ明記せずとも縦棒「|」区切りと書かれている時点で概ね察せるだろうと思ったので、正規表現という単語はカラム幅の都合もあり省略しました。