### PR TITLE
英大文字のお気に入りタグから英小文字のカラムを開くように修正

### DIFF
--- a/app/javascript/mastodon/features/compose/components/favourite_tags.js
+++ b/app/javascript/mastodon/features/compose/components/favourite_tags.js
@@ -69,7 +69,7 @@ class FavouriteTags extends React.PureComponent {
           <i className={`fa fa-fw fa-${this.visibilityToIcon(tag.get('visibility'))}`} />
         </div>
         <Link
-           to={`/timelines/tag/${tag.get('name')}`}
+           to={`/timelines/tag/${tag.get('name').toLowerCase()}`}
            className='favourite-tags__name'
            key={tag.get('name')}
         >


### PR DESCRIPTION
ReactのLinkタグのリンク先にtoLowerCase()を噛ませることで英小文字のカラムを開くように修正しました

related #62