### PR TITLE
お気に入りタグをidでsortする

### DIFF
--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   respond_to :json
 
   def index
-    @favourite_tags = current_account.favourite_tags.includes(:tag).map(&:to_json_for_api)
+    @favourite_tags = current_account.favourite_tags.order(:id).includes(:tag).map(&:to_json_for_api)
     render json: @favourite_tags
   end
 end

--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -20,7 +20,7 @@
 
 %table.table
   %tbody
-    - current_account.favourite_tags.each do |fav_tag|
+    - current_account.favourite_tags.order(:id).includes(:tag).each do |fav_tag|
       %tr
         %td
           = fa_icon 'tag'


### PR DESCRIPTION
今までのコードでは無邪気にぽすぐれ叩いていて帰ってきた順番をそのまま使ってただけだったので、
お気に入りタグをidでsortすることでユーザが並び順を(再作成すれば一応)制御できるようにしてはみました。

再作成せずにレコードのUPDATEでスマートに済ませる方法はちょっと思いつかず…
orderカラムとか作るしかないんでしょうかね

related #51 