### PR TITLE
correcting visibility setting (#71)

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -138,7 +138,9 @@ const setDefaultTag = (state, text, visibility) => {
   return state.withMutations(map => {
     map.update('text', oldText => oldText.replace(replaceRE, '') + (text === '' ? '' : ` ${text}`));
     map.set('defaultText', text);
-    map.set('privacy', (visibility === '' ? state.get('default_privacy') : visibility));
+    if (visibility !== '') {
+      map.set('privacy', visibility);
+    }
     map.set('tag_privacy', visibility);
   });
 };


### PR DESCRIPTION
add the small change of visibility setting to solve the problem reported in #71 

`setDefaultTag`においてprivacyにはvisibilityが空であるときに`state.get('default_privacy')`を設定していますが、`clearAll`にて`tag_privacy`か`default_privacy`のどちらかが必ず設定されるため必要ないと思われます。
#71 の問題を解決するために、visibilityが空であるときには何もしないようにします。