### PR TITLE
[WIP] Enable to recognize Japanese string as URL paths

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -131,7 +131,7 @@ class Formatter
   end
 
   def link_html(url)
-    url    = Addressable::URI.parse(url).display_uri.to_s
+    url    = Addressable::URI.parse(url).to_s
     prefix = url.match(/\Ahttps?:\/\/(www\.)?/).to_s
     text   = url[prefix.length, 30]
     suffix = url[prefix.length + 30..-1]

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class FetchLinkCardService < BaseService
-  URL_PATTERN = %r{https?://\S+}
+  URL_PATTERN = %r{
+    (                                                                                   #   $1 URL
+      (https?:\/\/)?                                                                    #   $2 Protocol (optional)
+      (#{Twitter::Regex[:valid_domain]})                                                       #   $3 Domain(s)
+      (?::(#{Twitter::Regex[:valid_port_number]}))?                                            #   $4 Port number (optional)
+      (/#{Twitter::Regex[:valid_url_path]}*)?                                                  #   $5 URL Path and anchor
+      (\?#{Twitter::Regex[:valid_url_query_chars]}*#{Twitter::Regex[:valid_url_query_ending_chars]})? #   $6 Query String
+    )
+  }iox
 
   def call(status)
     # Get first http/https URL that isn't local
@@ -24,7 +32,7 @@ class FetchLinkCardService < BaseService
 
   def parse_urls(status)
     if status.local?
-      urls = status.text.match(URL_PATTERN).to_a.map { |uri| Addressable::URI.parse(uri).normalize }
+      urls = status.text.scan(URL_PATTERN).map { |array| Addressable::URI.parse(array[0]).normalize }
     else
       html  = Nokogiri::HTML(status.text)
       links = html.css('a')

--- a/config/initializers/twitter_regex.rb
+++ b/config/initializers/twitter_regex.rb
@@ -1,0 +1,43 @@
+module Twitter
+  class Regex
+    require 'yaml'
+
+    REGEXEN[:valid_general_url_path_chars] = /[a-z\p{Cyrillic}0-9!\*';:=\+\,\.\$\/%#\[\]\p{Pd}_~&\|@#{LATIN_ACCENTS}\p{Hiragana}\p{Katakana}ー\p{Han}]/iou
+    REGEXEN[:valid_url_path_ending_chars] = /[a-z\p{Cyrillic}0-9=_#\/\+\-#{LATIN_ACCENTS}\p{Hiragana}\p{Katakana}ー\p{Han}]|(?:#{REGEXEN[:valid_url_balanced_parens]})/iou
+    REGEXEN[:valid_url_balanced_parens] = /
+      \(
+        (?:
+          #{REGEXEN[:valid_general_url_path_chars]}+
+          |
+          # allow one nested level of balanced parentheses
+          (?:
+            #{REGEXEN[:valid_general_url_path_chars]}*
+            \(
+              #{REGEXEN[:valid_general_url_path_chars]}+
+            \)
+            #{REGEXEN[:valid_general_url_path_chars]}*
+          )
+        )
+      \)
+    /iox
+    REGEXEN[:valid_url_path] = /(?:
+      (?:
+        #{REGEXEN[:valid_general_url_path_chars]}*
+        (?:#{REGEXEN[:valid_url_balanced_parens]} #{REGEXEN[:valid_general_url_path_chars]}*)*
+        #{REGEXEN[:valid_url_path_ending_chars]}
+      )|(?:#{REGEXEN[:valid_general_url_path_chars]}+\/)
+    )/iox
+    REGEXEN[:valid_url] = %r{
+      (                                                                                     #   $1 total match
+        (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter
+        (                                                                                   #   $3 URL
+          (https?:\/\/)?                                                                    #   $4 Protocol (optional)
+          (#{REGEXEN[:valid_domain]})                                                       #   $5 Domain(s)
+          (?::(#{REGEXEN[:valid_port_number]}))?                                            #   $6 Port number (optional)
+          (/#{REGEXEN[:valid_url_path]}*)?                                                  #   $7 URL Path and anchor
+          (\?#{REGEXEN[:valid_url_query_chars]}*#{REGEXEN[:valid_url_query_ending_chars]})? #   $8 Query String
+        )
+      )
+    }iox
+  end
+end


### PR DESCRIPTION
Related #57 

Currently, only ASCII (and Cyrillic) characters and symbols are recognized as URL paths and automatically linked. The behavior is by design of `twitter-text` gem. However, [`FetchLinkCardService`](https://github.com/tootsuite/mastodon/blob/1618b68bfa740ed655ac45d7d5f4f46fed6c8c62/app/services/fetch_link_card_service.rb#L4) also recognizes non-ASCII paths as a part of the URL.
This PR tries to solve inconsistency between them. In particular, this enables to recognize Japanese string as URL paths. The reasons for this change are as follows.

1. Nowadays, many Japanese websites are using Japanese characters (Hiragana, Katakana and Kanji) in their URL.
2. Usually, **percent-encoding** is used for URLs containing non-ASCII string, but we can not understand the encoded URL. (Can you understand what the following URL refers to? https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC)

After this change, the URL contains Japanese characters is shown as the following image.
![2017-09-11 2](https://user-images.githubusercontent.com/8458066/30265335-d4070de4-9716-11e7-8654-0e3bd75366bb.png)

The problem that FetchLinkCardService recognizes multiple URLs separated by double-byte space as a single URL has also been resolved.

- [x] Enable to recognize Japanese string as URL paths
- [x] Solve the problem in FetchLinkCardService
- [ ] Add some test cases