### PR TITLE
imagemagickのバージョンに依存して異なる動作になっていた部分を修正

### DIFF
--- a/lib/paperclip/img_converter.rb
+++ b/lib/paperclip/img_converter.rb
@@ -5,7 +5,9 @@ module Paperclip
   # to convert images to JPG (except for transparent PNG)
   class ImgConverter < Processor
     def make
-      if identify('-format "%[opaque]" :src', src: File.expand_path(file.path)).strip == 'true'
+      opaque = identify('-format "%[opaque]" :src', src: File.expand_path(file.path)).strip.downcase
+
+      if opaque == 'true'
         basename = File.basename(file.path, File.extname(file.path))
         dst_name = basename << ".jpg"
 
@@ -15,9 +17,7 @@ module Paperclip
                 src: File.expand_path(file.path),
                 dst: File.expand_path(dst.path))
 
-        src_filesize = identify('-format %b :src', src: File.expand_path(file.path)).to_i
-        dst_filesize = identify('-format %b :dst', dst: File.expand_path(dst.path)).to_i
-        if src_filesize > dst_filesize
+        if @file.size > dst.size
           attachment.instance.file_content_type = 'image/jpeg'
           return dst
         end


### PR DESCRIPTION
不透明かどうかを取得する最初のidentifyの結果が、imagemagickのバージョン依存で
'true'、'True'、'true\n'の三種類が確認されたいるためstripに加えてdowncaseも付けました。

また、ファイルサイズを取得するidentifyもimagemagickの7系から最後にKやMなどの補助単位を付けるヒューマンリーダブルな方向に行っており正しく動作しておらず、
単にRubyのFileクラスのsizeメソッドを使えばよいのではないかという指摘を受けたので修正しました。

本バグの修正にあたっては末代鯖のhotaさんとunaristさんのご協力をいただきました。