### PR TITLE
アカウント個別ページのadmin表示を削除

### DIFF
--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -26,7 +26,7 @@
         %span @#{account.local_username_and_domain}
         = fa_icon('lock') if account.locked?
 
-    - if account.user_admin?
+    - if false && account.user_admin?
       .roles
         .account-role
           = t 'accounts.roles.admin'


### PR DESCRIPTION
アカウントの個別ページの新デザインに存在する、管理者権限を持つユーザにのみ表示されるadminマークを削除します。

現時点ではアカウントの個別ページにまで僕が管理者であるとの表示をする必要性を感じられず、また表示したくもありません。