### PR TITLE
メニューにアイマストドンFAQを追加

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -24,6 +24,7 @@ const messages = defineMessages({
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
   info: { id: 'navigation_bar.info', defaultMessage: 'Extended information' },
   pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned toots' },
+  faq: { id: 'navigation_bar.faq', defaultMessage: 'FAQ(Only available in Japanese)' },
 });
 
 const mapStateToProps = state => ({
@@ -90,6 +91,7 @@ export default class GettingStarted extends ImmutablePureComponent {
           {navItems}
           <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)} />
           <ColumnLink icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />
+          <ColumnLink icon='question' text={intl.formatMessage(messages.faq)} href='http://faq.imastodon.net/getting-started/' targetWindow='_blank' />
           <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
           <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
         </div>

--- a/app/javascript/mastodon/features/ui/components/column_link.js
+++ b/app/javascript/mastodon/features/ui/components/column_link.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 
-const ColumnLink = ({ icon, text, to, href, method }) => {
+const ColumnLink = ({ icon, text, to, href, method, targetWindow }) => {
   if (href) {
     return (
-      <a href={href} className='column-link' data-method={method}>
+      <a href={href} className='column-link' data-method={method} target={targetWindow}>
         <i className={`fa fa-fw fa-${icon} column-link__icon`} />
         {text}
       </a>
@@ -27,6 +27,11 @@ ColumnLink.propTypes = {
   href: PropTypes.string,
   method: PropTypes.string,
   hideOnMobile: PropTypes.bool,
+  targetWindow: PropTypes.string,
+};
+
+ColumnLink.defaultProps = {
+  targetWindow: '_self',
 };
 
 export default ColumnLink;

--- a/app/javascript/mastodon/locales/ja-IM.json
+++ b/app/javascript/mastodon/locales/ja-IM.json
@@ -114,6 +114,7 @@
   "navigation_bar.preferences": "ユーザー設定",
   "navigation_bar.public_timeline": "ライブステージ",
   "navigation_bar.pins": "固定されたあふぅ",
+  "navigation_bar.faq": "アイマストドンかんたんガイド",
   "notification.favourite": "{name} さんがあなたのあふぅにティンと来たようです",
   "notification.follow": "{name} さんから名刺を頂きました",
   "notification.mention": "{name} さんがReあふぅしました",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -114,6 +114,7 @@
   "navigation_bar.preferences": "ユーザー設定",
   "navigation_bar.public_timeline": "連合タイムライン",
   "navigation_bar.pins": "固定されたトゥート",
+  "navigation_bar.faq": "アイマストドンかんたんガイド",
   "notification.favourite": "{name}さんがあなたのトゥートをお気に入りに登録しました",
   "notification.follow": "{name}さんにフォローされました",
   "notification.mention": "{name}さんがあなたに返信しました",

--- a/app/javascript/styles/custom.scss
+++ b/app/javascript/styles/custom.scss
@@ -1,6 +1,3 @@
 @import 'application';
 @import 'favourite_tags';
-
-.getting-started {
-  background-size: contain;
-}
+@import 'getting_started';

--- a/app/javascript/styles/getting_started.scss
+++ b/app/javascript/styles/getting_started.scss
@@ -1,0 +1,7 @@
+.getting-started {
+    background-size: contain;
+  }
+  
+  .column-link {
+    padding: 12px 15px;
+  }


### PR DESCRIPTION
スタートメニューの項目にアイマストドンFAQを追加しました。

項目追加に伴い縦が狭くなったため、column-linkクラスの高さ方向のマージンを少し減らし、
ついでにcustom.scssに直書きだったものをファイルに切り出しました。