### PR TITLE
スマホログイン画面のロゴサイズ指定修正

### DIFF
--- a/app/javascript/styles/containers.scss
+++ b/app/javascript/styles/containers.scss
@@ -24,7 +24,7 @@
     align-items: center;
 
     img {
-      height: 84px;
+      height: 64px;
       margin-right: 10px;
     }
 


### PR DESCRIPTION
width 320px の画面が以下になります。

![02](https://user-images.githubusercontent.com/11332152/30480571-55fd0d9e-9a55-11e7-8cf7-38bd44b06550.jpg)

max-width の指定でスマホのみサイズ指定変更もアリでしたが、
そこまでの必要はないかと思いこのように修正しました。

fixed #72