### PR TITLE
Fix favourite tags lock icon position

### DIFF
--- a/app/javascript/mastodon/features/compose/components/favourite_tags.js
+++ b/app/javascript/mastodon/features/compose/components/favourite_tags.js
@@ -93,10 +93,10 @@ class FavouriteTags extends React.PureComponent {
 
     return (
       <div className='favourite-tags'>
-        <div className='favourite-tags__header'>
+        <div className='compose__extra__header'>
           <i className='fa fa-tag' />
           <div className='favourite-tags__header__name'>{intl.formatMessage(messages.favourite_tags)}</div>
-          <div className='favourite-tags__lock'>
+          <div className='compose__extra__header__icon'>
             <a href='/settings/favourite_tags'>
               <i className='fa fa-gear' />
             </a>

--- a/app/javascript/styles/custom.scss
+++ b/app/javascript/styles/custom.scss
@@ -1,5 +1,6 @@
 @import 'application';
 @import 'imastodon/announcements';
+@import 'imastodon/compose_common';
 @import 'imastodon/favourite_tags';
 @import 'imastodon/getting_started';
 @import 'imastodon/statuses';

--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -1,0 +1,32 @@
+.compose__extra__header {
+    background: $ui-base-color;
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    background: lighten($ui-base-color, 4%);
+    font-size: 16px;
+  
+    a {
+      color: $white;
+    }
+  
+    > i {
+      padding-right: 4px;
+    }
+  
+    &__icon {
+      background: transparent;
+      position: absolute;
+      color: $white;
+      border: 0;
+      padding: 0;
+      right: 20px;
+      top: 8px;
+      text-align: center;
+  
+      i {
+        width: 14px;
+      }
+    }
+  }

--- a/app/javascript/styles/imastodon/favourite_tags.scss
+++ b/app/javascript/styles/imastodon/favourite_tags.scss
@@ -50,7 +50,9 @@
 
 .favourite-tags__lock {
   position: absolute;
+  top: 50%;
   right: 20px;
+  margin-top: -7px;
   width: 14px;
   text-align: center;
 }


### PR DESCRIPTION
firefoxにて発生していた、タグロックアイコンの垂直方向の位置が初期配置時のみずれていた問題を修正したcommitをcherry-pickしました。

## before
![image](https://user-images.githubusercontent.com/24884114/31406913-0510efde-ae3e-11e7-8f92-97c588f29f8d.png)

## after
![image](https://user-images.githubusercontent.com/24884114/31406915-09a84cb8-ae3e-11e7-9463-ba1623183dcd.png)
