### PR TITLE
Improvement of delete button

### DIFF
--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -28,7 +28,4 @@
         %td
           = I18n.t("statuses.visibilities.#{fav_tag.visibility}")
         %td
-          = form_for fav_tag, url: settings_favourite_tag_url(fav_tag), method: :delete do |f|
-            = f.button :button, type: :submit, class: :negative do
-              = fa_icon('times')
-              = t('favourite_tags.delete')
+          = table_link_to 'trash', t('favourite_tags.delete'), settings_favourite_tag_path(fav_tag), method: :delete


### PR DESCRIPTION
お気に入りタグ設定画面の削除ボタンの見た目が変更されます。

## before
![image](https://user-images.githubusercontent.com/24884114/31404193-55ac90d6-ae36-11e7-9e81-703e465a9c9a.png)

## after
![image](https://user-images.githubusercontent.com/24884114/31404200-5891634e-ae36-11e7-920a-64690e59d6da.png)
