### PR TITLE
rename database when environments is development or test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
 development:
   <<: *default
-  database: mastodon_development
+  database: imastodon_development
   username: <%= ENV['DB_USER'] %>
   password: <%= ENV['DB_PASS'] %>
   host: <%= ENV['DB_HOST'] %>
@@ -17,7 +17,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: mastodon_test<%= ENV['TEST_ENV_NUMBER'] %>
+  database: imastodon_test<%= ENV['TEST_ENV_NUMBER'] %>
   username: <%= ENV['DB_USER'] %>
   password: <%= ENV['DB_PASS'] %>
   host: <%= ENV['DB_HOST'] %>


### PR DESCRIPTION
アイマストドンにも独自機能が増え、本家にないテーブルが追加されたりするなど、そろそろdb:dropおよびdb:setupを繰り返すのが色々面倒になってきたのでdev環境とtest環境において用いるデータベース名を変更します。