### PR TITLE
投稿欄の「はじめましての方へ」を閉じている際に中のリンクにフォーカスが当たると表示がおかしくなる不具合を修正

### DIFF
--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -69,7 +69,7 @@ class Announcements extends React.PureComponent {
             <div className='announcements__body'>
               <p>{ this.nl2br(intl.formatMessage(messages.welcome, { domain: document.title }))}</p>
               {hashtags.map((hashtag, i) =>
-                <Link key={i} to={`/timelines/tag/${hashtag}`}>
+                <Link key={i} to={`/timelines/tag/${hashtag}`} tabIndex={this.state.show ? undefined : -1}>
                   #{hashtag}
                 </Link>
               )}


### PR DESCRIPTION
Fix #93 