### PR TITLE
add TrendTag function and API

### DIFF
--- a/app/controllers/api/v1/trend_tags_controller.rb
+++ b/app/controllers/api/v1/trend_tags_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Api::V1::TrendTagsController < Api::BaseController
+  respond_to :json
+
+  def show
+    trend_score = {
+      'updated_at' => redis.hget('trend_tag', 'updated_at'),
+      'score' => JSON.parse(redis.hget('trend_tag', 'score').presence || '{}'),
+    }
+    render json: trend_score
+  end
+
+  private
+
+  def redis
+    Redis.current
+  end
+end

--- a/app/controllers/api/v1/trend_tags_controller.rb
+++ b/app/controllers/api/v1/trend_tags_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::TrendTagsController < Api::BaseController
     trend_score = {
       'updated_at' => redis.hget('trend_tag', 'updated_at'),
       'score' => JSON.parse(redis.hget('trend_tag', 'score').presence || '{}'),
+      'score_ex' => JSON.parse(redis.hget('trend_tag', 'score_ex').presence || '{}'),
     }
     render json: trend_score
   end

--- a/app/models/statuses_tag.rb
+++ b/app/models/statuses_tag.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: statuses_tags
+#
+#  status_id  :integer          not null, primary key
+#  tag_id     :integer          not null
+#
+
+class StatusesTag < ApplicationRecord
+  class << self
+    def calc_trend
+      unless redis.exists('trend_tag')
+        redis.hset('trend_tag', 'updated_at', Time.now.utc.iso8601)
+      end
+      before = JSON.parse(redis.hget('trend_tag', 'before').presence || '{}')
+      last = JSON.parse(redis.hget('trend_tag', 'last').presence || '{}')
+      now = JSON.parse(aggregate_tags_in.to_json)
+      trend_score = {}
+      tag_keys(before, last, now).each do |k|
+        b = before[k].to_i # to_i converts nil to 0
+        l = last[k].to_i
+        n = now[k].to_i
+        tag = Tag.find(k.to_i)
+        trend_score[tag[:name]] = score(now: n, last: l, before: b)
+      end
+      redis.hmset('trend_tag', 'updated_at', Time.now.utc.iso8601, 'score', trend_score.to_json, 'last', now.to_json, 'before', last.to_json)
+    end
+
+    private
+
+    def tag_keys(*args)
+      args.map(&:keys).flatten.uniq
+    end
+
+    def score(now: 0, last: 0, before: 0)
+      now + (now - last) + (last * 3 / 4.0) + ((last - before) / 2.0) + (before / 4.0)
+    end
+
+    def aggregate_tags_in(t: 10.minutes, until_t: Time.now.utc)
+      status_ids = status_ids_in((until_t - t)..until_t)
+      StatusesTag.where(status_id: status_ids).group(:tag_id).count
+    end
+
+    def status_ids_in(time_range)
+      Status.where(created_at: time_range, local: true).map(&:id)
+    end
+
+    def redis
+      Redis.current
+    end
+  end
+end

--- a/app/workers/scheduler/trend_tag_scheduler.rb
+++ b/app/workers/scheduler/trend_tag_scheduler.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'sidekiq-scheduler'
+
+class Scheduler::TrendTagScheduler
+  include Sidekiq::Worker
+
+  def perform
+    StatusesTag.calc_trend
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,7 @@ Rails.application.routes.draw do
       end
 
       resources :favourite_tags, only: [:index, :create, :destroy], param: :tag
+      resource :trend_tag, only: [:show]
     end
 
     namespace :web do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,3 +27,6 @@
   ip_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::IpCleanupScheduler
+  trend_tag_scheduler:
+    cron: '5-55/10 * * * *'
+    class: Scheduler::TrendTagScheduler


### PR DESCRIPTION
Related #85.

Add a function aggregating trend tags using statuses in the past 30 minutes, and an API showing trend tags.

過去30分間の投稿からトレンドタグを集計する機能、および集計結果を表示するAPIを追加します。

## 集計について
集計は10分ごとに行います。
10分前から現在までに用いられたハッシュタグとその使用回数を取得し、Redisに格納してある1期前(10\~20分前)と2期前(20\~30分前)の使用回数データも用いて集計します。

トレンドスコアの算出は以下の計算式で行います。
当期の使用回数をn、1期前の使用回数をl、2期前の使用回数をbとすると
`n + (n - l) + (l * 3 / 4.0) + ((l - b) / 2.0) + (b / 4.0)`
つまり、

|  | 2期前 | 1期前 | 当期 |
| -- | -- | -- | -- |
| 使用回数 | ×0.25 | ×0.75 | ×1 |
| 前期からの増分 | -- | ×0.5 | ×1 |
| スコア | -- | -- | X |

この表の各倍率をかけて足した値がXになります。

具体例)
タグA

||0:00|0:10|0:20|0:30|0:40|0:50|1:00|1:10|1:20|
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
|  回数   | 0 | 2 | 4 | 4 | 10 | 4 | 4 | 0 | 0 |
|  増分   | 0 | 2 | 2 | 0 | 6 | -6 | 0 | -4 | 0 |
| スコア | 0 | 4 | 8.5 | 8.5 | 20 | 9.5 | 6.5 | 0 | -1 |

タグB

||0:00|0:10|0:20|0:30|0:40|0:50|1:00|1:10|1:20|
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
|  回数   | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 |
|  増分   | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| スコア | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 |

増分を計算に含めることで、一気に盛り上がったタグの値を急上昇させることができます。(タグAの0:40)
前期、前々期の値を計算に使用することで、使用回数が減少した場合でも、スコアの下落をある程度なだらかにすることができます。(タグAの0:50)
常に同じペースで使用されるハッシュタグは増分が0に近くなるため、同じ使用回数であっても、前期から回数が増えた(盛り上がった)場合に比べてスコアが低くなります。(0:20と0:30)

**より精度の良い計算式募集中です**

## APIについて

`GET https://imastodon.net/api/v1/trend_tag`
でトレンドタグの集計結果をJSON形式で返します。アクセストークンは不要にしています。
![trend](https://user-images.githubusercontent.com/8458066/32320804-51371f84-c002-11e7-8d4b-9f843aa8141d.PNG)
なお、過去30分間にハッシュタグが一切使われていない場合は以下のようなレスポンスになります。
![trend2](https://user-images.githubusercontent.com/8458066/32320903-b66cc48a-c002-11e7-8da4-eaf78d5fc4df.PNG)
