### PR TITLE
v2.0.0追従に伴い通知設定の画面のパスが変わったので修正

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -37,8 +37,8 @@ export default class ColumnSettings extends React.PureComponent {
         </div>
 
         <div className='column-settings__section'>
-          <a href='/settings/preferences' className='text-btn column-header__setting-btn'>
-            <FormattedMessage id='notifications.column_settings.notify_block' defaultMessage='Notify Block Setting' />
+          <a href='/settings/notifications' className='text-btn column-header__setting-btn'>
+            <FormattedMessage id='notifications.column_settings.notify_block' defaultMessage='Notifications Block Setting' />
           </a>
         </div>
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -123,7 +123,7 @@
   "notifications.clear": "Clear notifications",
   "notifications.clear_confirmation": "Are you sure you want to permanently clear all your notifications?",
   "notifications.column_settings.alert": "Desktop notifications",
-  "notifications.column_settings.notify_block": "Block settings for notify that are not from follow or follower",
+  "notifications.column_settings.notify_block": "Notifications Block Setting",
   "notifications.column_settings.favourite": "Favourites:",
   "notifications.column_settings.follow": "New followers:",
   "notifications.column_settings.mention": "Mentions:",

--- a/app/javascript/mastodon/locales/ja-IM.json
+++ b/app/javascript/mastodon/locales/ja-IM.json
@@ -124,7 +124,7 @@
   "notifications.clear": "ホワイトボードを消す",
   "notifications.clear_confirmation": "本当にホワイトボードを消しますか？",
   "notifications.column_settings.alert": "デスクトップ通知",
-  "notifications.column_settings.notify_block": "フォロー/フォロワー外からの通知のブロック設定",
+  "notifications.column_settings.notify_block": "フォロー/フォロワー外からの通知ブロック設定",
   "notifications.column_settings.favourite": "ティン！",
   "notifications.column_settings.follow": "新しいフォロワー",
   "notifications.column_settings.mention": "Reあふぅ",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -124,7 +124,7 @@
   "notifications.clear": "通知を消去",
   "notifications.clear_confirmation": "本当に通知を消去しますか？",
   "notifications.column_settings.alert": "デスクトップ通知",
-  "notifications.column_settings.notify_block": "フォロー/フォロワー外からの通知のブロック設定",
+  "notifications.column_settings.notify_block": "フォロー/フォロワー外からの通知ブロック設定",
   "notifications.column_settings.favourite": "お気に入り",
   "notifications.column_settings.follow": "新しいフォロワー",
   "notifications.column_settings.mention": "返信",


### PR DESCRIPTION
それに加え、chromeで表示した際に日本語が一文字だけはみ出てしまっていたので一文字削りました
