### PR TITLE
トレンドタグのリファクタリング

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,7 +259,7 @@ Rails.application.routes.draw do
       end
 
       resources :favourite_tags, only: [:index, :create, :destroy], param: :tag
-      resource :trend_tag, only: [:show]
+      resource :trend_tags, only: [:show]
     end
 
     namespace :web do


### PR DESCRIPTION
スコアを計算するメソッドでredisの格納までやっているのはメソッドの責任範囲的に微妙じゃないかと思ったので切り出しました。

あとレビュー漏れで申し訳ないのですが取得するトレンドタグのスコアは単数ではなく複数なので、パスはGET /api/v1/trend_tagsになる気がします。