### PR TITLE
iPhone4のような高さ480px以下の端末のスタートメニューCSS修正

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -86,28 +86,30 @@ export default class GettingStarted extends ImmutablePureComponent {
 
     return (
       <Column icon='asterisk' heading={intl.formatMessage(messages.heading)} hideHeadingOnMobile>
-        <div className='getting-started__wrapper'>
-          <ColumnSubheading text={intl.formatMessage(messages.navigation_subheading)} />
-          {navItems}
-          <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)} />
-          <ColumnLink icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />
-          <ColumnLink icon='question' text={intl.formatMessage(messages.faq)} href='http://faq.imastodon.net/getting-started/' targetWindow='_blank' />
-          <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
-          <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
-        </div>
+        <div className='scrollable optionally-scrollable'>
+          <div className='getting-started__wrapper'>
+            <ColumnSubheading text={intl.formatMessage(messages.navigation_subheading)} />
+            {navItems}
+            <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)} />
+            <ColumnLink icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />
+            <ColumnLink icon='question' text={intl.formatMessage(messages.faq)} href='http://faq.imastodon.net/getting-started/' targetWindow='_blank' />
+            <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
+            <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
+          </div>
 
-        <div className='getting-started__footer scrollable optionally-scrollable'>
-          <div className='static-content getting-started'>
-            <p>
-              <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>
-            </p>
-            <p>
-              <FormattedMessage
-                id='getting_started.open_source_notice'
-                defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
-                values={{ github: <a href={github_url} rel='noopener' target='_blank'>{github_name}</a> }}
-              />
-            </p>
+          <div className='getting-started__footer'>
+            <div className='static-content getting-started'>
+              <p>
+                <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>
+              </p>
+              <p>
+                <FormattedMessage
+                   id='getting_started.open_source_notice'
+                   defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
+                   values={{ github: <a href={github_url} rel='noopener' target='_blank'>{github_name}</a> }}
+                />
+              </p>
+            </div>
           </div>
         </div>
       </Column>

--- a/app/javascript/styles/imastodon/getting_started.scss
+++ b/app/javascript/styles/imastodon/getting_started.scss
@@ -5,3 +5,9 @@
 .column-link {
   padding: 12px 15px;
 }
+
+@media screen and (max-height: 480px) {
+  .getting-started__wrapper {
+    height: 360px;
+  }
+}

--- a/app/javascript/styles/imastodon/getting_started.scss
+++ b/app/javascript/styles/imastodon/getting_started.scss
@@ -5,9 +5,3 @@
 .column-link {
   padding: 12px 15px;
 }
-
-@media screen and (max-height: 480px) {
-  .getting-started__wrapper {
-    height: 360px;
-  }
-}


### PR DESCRIPTION
高さ480px以下の端末の場合スタートメニューが窮屈な印象を受けましたので、
修正致しました。

|before|after|
|---|---|
|![](https://user-images.githubusercontent.com/11332152/32990437-aa337f52-cd6c-11e7-8674-c8bfbecf7bf9.jpg)|![](https://user-images.githubusercontent.com/11332152/32990440-b439da5a-cd6c-11e7-85b5-48d033a20737.jpg)|

iPhone5以降(最近)の高さ480pxを超える端末では影響ありません。