### PR TITLE
チュートリアル機能を再表示するためのRakeタスク追加

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -36,14 +36,16 @@ namespace :mastodon do
 
   desc 'Initialize a user\'s web settings, identified by the USERNAME environment variable'
   task clear_settings: :environment do
-    include RoutingHelper
     account_username = ENV.fetch('USERNAME')
-    user = User.joins(:account).where(accounts: { username: account_username })
+    account = Account.find_local!(account_username)
 
-    if user.present?
-      Web::Setting.where(user: user).first_or_initialize(user: user)
-      Web::Setting.where(user: user).update(data: {})
-      puts "#{account_username}'s web settings is Initialized."
+    if account
+      Web::Setting.where(user: account.user).first_or_initialize(user: account.user)
+      if Web::Setting.where(user: account.user).update(data: {})
+        puts "#{account_username}'s web settings is initialized."
+      else
+        puts "#{account_username}'s web settings cannot initialized. Please make sure the `#{account_username}`'s web settings exists."
+      end
     else
       puts "User could not be found; please make sure an Account with the `#{account_username}` username exists."
     end

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -40,11 +40,12 @@ namespace :mastodon do
     account = Account.find_local!(account_username)
 
     if account
-      Web::Setting.where(user: account.user).first_or_initialize(user: account.user)
-      if Web::Setting.where(user: account.user).update(data: {})
-        puts "#{account_username}'s web settings is initialized."
+      setting = Web::Setting.find_or_initialize_by(user: account.user)
+      setting.data = {}
+      if setting.save
+        puts "#{account_username}'s web settings have been initialized."
       else
-        puts "#{account_username}'s web settings cannot initialized. Please make sure the `#{account_username}`'s web settings exists."
+        puts "Could not initialize #{account_username}'s web settings. Please make sure the `#{account_username}`'s web settings exist."
       end
     else
       puts "User could not be found; please make sure an Account with the `#{account_username}` username exists."

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -34,6 +34,21 @@ namespace :mastodon do
     end
   end
 
+  desc 'Initialize a user\'s web settings, identified by the USERNAME environment variable'
+  task clear_settings: :environment do
+    include RoutingHelper
+    account_username = ENV.fetch('USERNAME')
+    user = User.joins(:account).where(accounts: { username: account_username })
+
+    if user.present?
+      Web::Setting.where(user: user).first_or_initialize(user: user)
+      Web::Setting.where(user: user).update(data: {})
+      puts "#{account_username}'s web settings is Initialized."
+    else
+      puts "User could not be found; please make sure an Account with the `#{account_username}` username exists."
+    end
+  end
+
   desc 'Add a user by providing their email, username and initial password.' \
        'The user will receive a confirmation email, then they must reset their password before logging in.'
   task add_user: :environment do


### PR DESCRIPTION
デバッグ用にweb_settingsテーブルのデータをクリアするRakeタスクを追加しました。

```rake mastodon:clear_settings USERNAME=<ユーザーID>```

のコマンドでクリアできます。