### PR TITLE
modify trendtag algorithm

### DIFF
--- a/app/controllers/api/v1/trend_tags_controller.rb
+++ b/app/controllers/api/v1/trend_tags_controller.rb
@@ -7,7 +7,6 @@ class Api::V1::TrendTagsController < Api::BaseController
     trend_score = {
       'updated_at' => redis.hget('trend_tag', 'updated_at'),
       'score' => JSON.parse(redis.hget('trend_tag', 'score').presence || '{}'),
-      'score_ex' => JSON.parse(redis.hget('trend_tag', 'score_ex').presence || '{}'),
     }
     render json: trend_score
   end

--- a/app/models/statuses_tag.rb
+++ b/app/models/statuses_tag.rb
@@ -13,73 +13,55 @@ class StatusesTag < ApplicationRecord
       unless redis.exists('trend_tag')
         redis.hset('trend_tag', 'updated_at', Time.now.utc.iso8601)
       end
-      before = JSON.parse(redis.hget('trend_tag', 'before').presence || '{}')
-      last = JSON.parse(redis.hget('trend_tag', 'last').presence || '{}')
-      now = JSON.parse(aggregate_tags_in.to_json)
+      level_l = JSON.parse(redis.hget('trend_tag', 'level_L').presence || '{}')
+      trend_l = JSON.parse(redis.hget('trend_tag', 'trend_L').presence || '{}')
+      now = aggregate_tags_in
 
-      score = calc_score(before, last, now)
-      redis.hmset('trend_tag', 'updated_at', Time.now.utc.iso8601, 'score', score.to_json, 'last', now.to_json, 'before', last.to_json)
-
-      score_ex, level_l, trend_l = calc_score_experimental(before, last, now)
-      redis.hmset('trend_tag', 'score_ex', score_ex.to_json, 'level_L', level_l.to_json, 'trend_L', trend_l.to_json)
+      score, level_now, trend_now = calc_score(level_l, trend_l, now)
+      redis.hmset('trend_tag', 'updated_at', Time.now.utc.iso8601, 'score', score.to_json, 'level_L', level_now.to_json, 'trend_L', trend_now.to_json)
     end
 
     private
 
-    def calc_score(before, last, now)
-      trend_score = {}
-      tag_keys(before, last, now).each do |k|
-        b = before[k].to_i # to_i converts nil to 0
-        l = last[k].to_i
-        n = now[k].to_i
-        tag = Tag.find(k.to_i)
-        trend_score[tag[:name]] = score(now: n, last: l, before: b)
-      end
-      trend_score
-    end
-
-    # Double Exponential Smoothing (experimental)
-    def calc_score_experimental(before, last, now)
-      level_l = JSON.parse(redis.hget('trend_tag', 'level_L').presence || '{}')
-      trend_l = JSON.parse(redis.hget('trend_tag', 'trend_L').presence || '{}')
+    # Double Exponential Smoothing
+    def calc_score(level_l, trend_l, now)
       level_now = {}
       trend_now = {}
-      trend_score_des = {}
-      tag_keys(before, last, now).each do |k|
+      trend_score = {}
+      tag_keys(level_l, now).each do |k|
         l_l = level_l[k].to_f
         t_l = trend_l[k].to_f
         n = now[k].to_i
         tag = Tag.find(k.to_i)
         sl = score_level(now: n, level_last: l_l, trend_last: t_l)
         st = score_trend(level: sl, level_last: l_l, trend_last: t_l)
+        if (sl + st) < 0.5
+          next
+        end
         level_now[k] = sl.round(3)
         trend_now[k] = st.round(3)
-        trend_score_des[tag[:name]] = (sl + st).round(3)
+        trend_score[tag[:name]] = (sl + st).round(2)
       end
-      [trend_score_des, level_now, trend_now]
+      [trend_score, level_now, trend_now]
     end
 
     def tag_keys(*args)
       args.map(&:keys).flatten.uniq
     end
 
-    def score(now: 0, last: 0, before: 0)
-      now + (now - last) + (last * 3 / 4.0) + ((last - before) / 2.0) + (before / 4.0)
-    end
-
-    # for Double Exponential Smoothing (experimental)
-    def score_level(now: 0, level_last: 0.0, trend_last: 0.0, alpha: 0.8)
+    # for Double Exponential Smoothing
+    def score_level(now: 0, level_last: 0.0, trend_last: 0.0, alpha: 0.5)
       alpha * now + (1 - alpha) * (level_last + trend_last)
     end
 
-    # for Double Exponential Smoothing (experimental)
+    # for Double Exponential Smoothing
     def score_trend(level: 0, level_last: 0.0, trend_last: 0.0, gamma: 0.3)
-      gamma * (level - level_last) + (1 - gamma) * trend_last
+      [gamma * (level - level_last) + (1 - gamma) * trend_last, 0].max # return 0 if trend is negative
     end
 
     def aggregate_tags_in(t: 10.minutes, until_t: Time.now.utc)
       status_ids = status_ids_in((until_t - t)..until_t)
-      StatusesTag.where(status_id: status_ids).group(:tag_id).count
+      StatusesTag.where(status_id: status_ids).group(:tag_id).count.map{|k, v| [k.to_s, v]}.to_h
     end
 
     def status_ids_in(time_range)


### PR DESCRIPTION
Related #85, #109, #115 

Modify trendtag aggregating algorithm.
- Delete the original algorithm
- Adjust parameters for Double Exponential Smoothing
- Return 0 as trend value if it's negative

トレンドスコアの計算方法を変更します。
- 独自のアルゴリズムは削除。二重指数平滑法を用いた算出に一本化。
- 二重指数平滑法の2つのパラメータを調整。(_&alpha;_ = 0.5, _&beta;_ = 0.3)
- トレンド値（統計用語のトレンド）がマイナスの場合は0を返すように変更。

この変更により、redis上のハッシュ'before', 'last', 'score_ex'の3つが不要になりますので、これら3つは削除して構いません。Railsコンソール上であれば、

```
redis = Redis.current
redis.hdel('trend_tag', 'before')
redis.hdel('trend_tag', 'last')
redis.hdel('trend_tag', 'score_ex')
```

で削除可能です。

また、今までは集計対象となるタグは「過去30分以内に1回以上使用されたもの」でしたが、この変更で「前回集計時点でトレンドスコアが0.1以上であるもの」になります。集計結果も、トレンドスコアが0.1以上であるタグとスコアのペアのみを保管します。この閾値0.1は実際の動向を見て調整が必要になる場合があると思います。

_&alpha;_ を0.5にし、トレンド値がマイナスの時にマイナスの補正をしないようにしたため、使用回数が0であるときには前回集計の0.5倍の値が今回の集計結果になります。今までは盛り上がっていたタグが使われなくなるとマイナスのトレンドスコアを出していましたが、それがなくなる上、盛り上がりが大きかったタグほど長く集計に残るようになります。