### PR TITLE
英大文字のお気に入りタグから英小文字のstreamingを開くようにしていたcommit( #64 )の戻し

### DIFF
--- a/app/javascript/mastodon/features/compose/components/favourite_tags.js
+++ b/app/javascript/mastodon/features/compose/components/favourite_tags.js
@@ -76,7 +76,7 @@ class FavouriteTags extends React.PureComponent {
           <i className={`fa fa-fw fa-${this.visibilityToIcon(tag.get('visibility'))}`} />
         </div>
         <Link
-           to={`/timelines/tag/${tag.get('name').toLowerCase()}`}
+           to={`/timelines/tag/${tag.get('name')}`}
            className='favourite-tags__name'
            key={tag.get('name')}
         >


### PR DESCRIPTION
- toLowerCaseが原因で https://github.com/imas/mastodon/pull/96 が期待する動作をしていないため。
- toLowerCaseを付加した理由のバグが https://github.com/tootsuite/mastodon/pull/4804 にて修正済みのため。

related #64 