### PR TITLE
お気に入りタグの公開範囲の候補からprivateを削除

### DIFF
--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -7,7 +7,7 @@
     = ff.input :name, placeholder: t('favourite_tags.name_of_tag')
   = f.input :visibility,
     label: t('simple_form.labels.defaults.setting_default_privacy'),
-    collection: Status.visibilities.keys - ['direct'],
+    collection: Status.visibilities.keys[0..1],
     wrapper: :with_label,
     include_blank: false,
     label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), content_tag(:span, I18n.t("statuses.visibilities.#{visibility}_long"), class: 'hint')]) },


### PR DESCRIPTION
現状、公開範囲がprivateであるタグ付き投稿はタグTLには表示されないため、お気に入りタグ機能の設定画面において公開範囲の候補にprivateが入っているのはユーザに混乱を招く可能性があります。
また、公開範囲がprivateであるお気に入りタグは4件しか登録されておらず、使用されている様子もありませんでした。
したがって、お気に入りタグ機能の設定画面において公開範囲の候補からprivateを削除します。

将来的に本家で自分の投稿が検索可能となるなどの変更があった場合には復活させるかもしれません。