### PR TITLE
make the favourite_tags list foldable

### DIFF
--- a/app/javascript/mastodon/components/fold_button.js
+++ b/app/javascript/mastodon/components/fold_button.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Motion from 'react-motion/lib/Motion';
+import Motion from '../features/ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
 import PropTypes from 'prop-types';
 

--- a/app/javascript/mastodon/components/fold_button.js
+++ b/app/javascript/mastodon/components/fold_button.js
@@ -1,40 +1,10 @@
 import React from 'react';
 import Motion from '../features/ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
-import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import IconButton from './icon_button';
 
-class IconButton extends React.PureComponent {
-
-  static propTypes = {
-    className: PropTypes.string,
-    title: PropTypes.string.isRequired,
-    icon: PropTypes.string.isRequired,
-    onClick: PropTypes.func,
-    size: PropTypes.number,
-    active: PropTypes.bool,
-    style: PropTypes.object,
-    activeStyle: PropTypes.object,
-    disabled: PropTypes.bool,
-    inverted: PropTypes.bool,
-    animate: PropTypes.bool,
-    overlay: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    size: 18,
-    active: false,
-    disabled: false,
-    animate: false,
-    overlay: false,
-  };
-
-  handleClick = (e) =>  {
-    e.preventDefault();
-
-    if (!this.props.disabled) {
-      this.props.onClick(e);
-    }
-  }
+export default class FoldButton extends IconButton {
 
   render () {
     const style = {
@@ -46,39 +16,60 @@ class IconButton extends React.PureComponent {
       ...(this.props.active ? this.props.activeStyle : {}),
     };
 
-    const classes = ['icon-button'];
+    const {
+      active,
+      animate,
+      className,
+      disabled,
+      expanded,
+      icon,
+      inverted,
+      overlay,
+      pressed,
+      tabIndex,
+      title,
+    } = this.props;
 
-    if (this.props.active) {
-      classes.push('active');
-    }
+    const classes = classNames(className, 'icon-button', {
+      active,
+      disabled,
+      inverted,
+      overlayed: overlay,
+    });
 
-    if (this.props.disabled) {
-      classes.push('disabled');
-    }
-
-    if (this.props.inverted) {
-      classes.push('inverted');
-    }
-
-    if (this.props.overlay) {
-      classes.push('overlayed');
-    }
-
-    if (this.props.className) {
-      classes.push(this.props.className);
+    if (!animate) {
+      // Perf optimization: avoid unnecessary <Motion> components unless
+      // we actually need to animate.
+      return (
+        <button
+          aria-label={title}
+          aria-pressed={pressed}
+          aria-expanded={expanded}
+          title={title}
+          className={classes}
+          onClick={this.handleClick}
+          style={style}
+          tabIndex={tabIndex}
+        >
+          <i className={`fa fa-fw fa-${icon}`} aria-hidden='true' />
+        </button>
+      );
     }
 
     return (
       <Motion defaultStyle={{ rotate: this.props.active ? 180 : 0 }} style={{ rotate: this.props.animate ? spring(this.props.active ? 0 : 180) : 0 }}>
         {({ rotate }) =>
           <button
-            aria-label={this.props.title}
-            title={this.props.title}
-            className={classes.join(' ')}
+            aria-label={title}
+            aria-pressed={pressed}
+            aria-expanded={expanded}
+            title={title}
+            className={classes}
             onClick={this.handleClick}
             style={style}
+            tabIndex={tabIndex}
           >
-            <i style={{ transform: `rotate(${rotate}deg)` }} className={`fa fa-fw fa-${this.props.icon}`} aria-hidden='true' />
+            <i style={{ transform: `rotate(${rotate}deg)` }} className={`fa fa-fw fa-${icon}`} aria-hidden='true' />
           </button>
         }
       </Motion>
@@ -86,5 +77,3 @@ class IconButton extends React.PureComponent {
   }
 
 }
-
-export default IconButton;

--- a/app/javascript/mastodon/components/foldable.js
+++ b/app/javascript/mastodon/components/foldable.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Motion from '../features/ui/util/optional_motion';
+import spring from 'react-motion/lib/spring';
+
+const Foldable = ({ fullHeight, minHeight, isVisible, children }) => (
+  <Motion defaultStyle={{ height: isVisible ? fullHeight : minHeight }} style={{ height: spring(!isVisible ? minHeight : fullHeight) }}>
+    {({ height }) =>
+      <div style={{ height: `${height}px`, overflow: 'hidden' }}>
+        {children}
+      </div>
+    }
+  </Motion>
+);
+
+Foldable.propTypes = {
+  fullHeight: PropTypes.number.isRequired,
+  minHeight: PropTypes.number.isRequired,
+  isVisible: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default Foldable;

--- a/app/javascript/mastodon/features/compose/components/favourite_tags.js
+++ b/app/javascript/mastodon/features/compose/components/favourite_tags.js
@@ -4,9 +4,12 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Link from 'react-router-dom/Link';
 import PropTypes from 'prop-types';
 import { injectIntl, defineMessages } from 'react-intl';
+import FoldButton from '../../../components/fold_button';
+import Foldable from '../../../components/foldable';
 
 const messages = defineMessages({
   favourite_tags: { id: 'compose_form.favourite_tags', defaultMessage: 'Favourite tags' },
+  toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
 });
 
 const icons = [
@@ -28,7 +31,12 @@ class FavouriteTags extends React.PureComponent {
   state = {
     lockedTag: ImmutableList(),
     lockedVisibility: ImmutableList(),
+    show: true,
   };
+
+  onClickCollapse = () => {
+    this.setState({ show: !this.state.show });
+  }
 
   componentDidMount () {
     this.props.refreshFavouriteTags();
@@ -101,10 +109,15 @@ class FavouriteTags extends React.PureComponent {
               <i className='fa fa-gear' />
             </a>
           </div>
+          <div className='favourite-tags__fold__icon'>
+            <FoldButton title={intl.formatMessage(messages.toggle_visible)} icon='caret-up' onClick={this.onClickCollapse} size={20} animate active={this.state.show} />
+          </div>
         </div>
-        <ul className='favourite-tags__body'>
-          {tags}
-        </ul>
+        <Foldable isVisible={this.state.show} fullHeight={this.props.tags.size * 30} minHeight={0} >
+          <ul className='favourite-tags__body'>
+            {tags}
+          </ul>
+        </Foldable>
       </div>
     );
   }

--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -3,7 +3,8 @@
     position: relative;
     display: flex;
     align-items: center;
-    padding: 8px 12px;
+    height: 26px;
+    padding: 4px 12px;
     background: lighten($ui-base-color, 4%);
     font-size: 16px;
   
@@ -21,8 +22,7 @@
       color: $white;
       border: 0;
       padding: 0;
-      right: 20px;
-      top: 8px;
+      right: 45px;
       text-align: center;
   
       i {

--- a/app/javascript/styles/imastodon/favourite_tags.scss
+++ b/app/javascript/styles/imastodon/favourite_tags.scss
@@ -31,7 +31,7 @@
 .favourite-tags__body li {
   display: flex;
   align-items: center;
-  padding: 10px;
+  padding: 6px 10px;
   position: relative
 }
 
@@ -79,4 +79,9 @@
   &:hover {
     background-color: lighten($error-value-color, 5%);
   }
+}
+
+.favourite-tags__fold__icon {
+  position: absolute;
+  right: 14px;
 }


### PR DESCRIPTION
make the favourite_tags list foldable like the announcement box.

お気に入りタグリストを、お知らせボックスと同様に折りたたみ可能にします。動作は以下の画像のような感じです。
![foldable](https://user-images.githubusercontent.com/8458066/34947037-4065b1a0-fa4c-11e7-8e10-07c934c8b1ba.gif)

変更点や仕様などは以下の通りです。
- リスト各項目の高さがちょっと大きすぎる気がしたので少し詰めています。

- リロードやページ遷移時はデフォルトで**開いた状態**にしてあります。閉じた状態のほうが好ましいということでしたら変更します。

- タグロック状態で開閉を行ってもタグロックは正常に動作し続けます。

- タグカラムからお気に入りタグの追加・削除をしたときも正常に動作します。（その上、高さの変化がアニメーションになりました）

この変更を行うにあたって、[announcements.js](https://github.com/fvh-P/mastodon/blob/bd132d41c373474d07bc9b317816747ac07f4515/app/javascript/mastodon/features/compose/components/announcements.js)からCollapsableを別ファイルに切り出した上で名前をFoldableに変更しています。(Collapsableが既に仕様違いで存在しているため)
announcements.jsは #74 でも変更される予定であるため、#74 を先にmergeした方がよいと思われます。 

#74 とこのPRが両方mergeされた後、お知らせボックスのデザインをお気に入りタグリストのデザインと同様のものに統一し、スタイルシートなどのリファクタリングを行う予定です。