### PR TITLE
tagTLのREST APIについて、認証時にはpublicとunlistedを、未認証時にはpublicのみを返すように変更

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -163,10 +163,15 @@ class Status < ApplicationRecord
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      where(visibility: [:public, :unlisted])
-      query = timeline_scope(local_only, false, false).tagged_with(tag)
+      if account
+        query = timeline_scope(local_only, false, false).tagged_with(tag)
 
-      apply_timeline_filters(query, account, local_only)
+        apply_timeline_filters(query, account, local_only)
+      else
+        query = timeline_scope(local_only, true, false).tagged_with(tag)
+
+        apply_timeline_filters(query, account, local_only)
+      end
     end
 
     def as_outbox_timeline(account)

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -7,34 +7,68 @@ describe Api::V1::Timelines::TagController do
 
   let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
 
-  before do
-    allow(controller).to receive(:doorkeeper_token) { token }
-  end
+  context 'with authoraized' do 
+    before do
+      allow(controller).to receive(:doorkeeper_token) { token }
+    end
 
-  context 'with a user context' do
-    let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
+    context 'with a user context' do
+      let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
 
-    describe 'GET #show' do
-      before do
-        PostStatusService.new.call(user.account, 'It is a #test')
+      describe 'GET #show' do
+        before do
+          PostStatusService.new.call(user.account, 'It is a public #test')
+          PostStatusService.new.call(user.account, 'It is a unlisted #test',{visibility: 'unlisted'})
+        end
+
+        it 'returns http success' do
+          get :show, params: { id: 'test' }
+          expect(response).to have_http_status(:success)
+          expect(response.headers['Link'].links.size).to eq(2)
+          expect(JSON.parse(response.body).length).to eq(2)
+        end
       end
+    end
 
-      it 'returns http success' do
-        get :show, params: { id: 'test' }
-        expect(response).to have_http_status(:success)
-        expect(response.headers['Link'].links.size).to eq(2)
+    context 'without a user context' do
+      let(:token) { Fabricate(:accessible_access_token, resource_owner_id: nil) }
+
+      describe 'GET #show' do
+        it 'returns http success' do
+          get :show, params: { id: 'test' }
+          expect(response).to have_http_status(:success)
+          expect(response.headers['Link']).to be_nil
+          expect(JSON.parse(response.body).length).to eq(0)
+        end
       end
     end
   end
 
-  context 'without a user context' do
-    let(:token) { Fabricate(:accessible_access_token, resource_owner_id: nil) }
+  context 'without authoraized' do 
+    context 'with a user context' do
+      describe 'GET #show' do
+        before do
+          PostStatusService.new.call(user.account, 'It is a public #test')
+          PostStatusService.new.call(user.account, 'It is a unlisted #test',{visibility: 'unlisted'})
+        end
 
-    describe 'GET #show' do
-      it 'returns http success' do
-        get :show, params: { id: 'test' }
-        expect(response).to have_http_status(:success)
-        expect(response.headers['Link']).to be_nil
+        it 'returns http success' do
+          get :show, params: { id: 'test' }
+          expect(response).to have_http_status(:success)
+          expect(response.headers['Link'].links.size).to eq(2)
+          expect(JSON.parse(response.body).length).to eq(1)
+        end
+      end
+    end
+
+    context 'without a user context' do
+      describe 'GET #show' do
+        it 'returns http success' do
+          get :show, params: { id: 'test' }
+          expect(response).to have_http_status(:success)
+          expect(response.headers['Link']).to be_nil
+          expect(JSON.parse(response.body).length).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
表題通りです。
rspecのtestも書きました

related #123 