### PR TITLE
お知らせ動的対応(二コフレver)

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Admin
+  class AnnouncementsController < BaseController
+    before_action :set_announcement, only: [:edit, :update, :destroy]
+    after_action :publish_updates, only: [:create, :update, :destroy]
+
+    def index
+      @announcements = Announcement.all
+    end
+
+    def new
+      @announcement = Announcement.new
+      fill_links!
+    end
+
+    def edit
+      fill_links!
+    end
+
+    def create
+      @announcement = Announcement.new(announcement_params)
+      if @announcement.save
+        redirect_to :admin_announcements
+      else
+        fill_links!
+        render :new
+      end
+    end
+
+    def update
+      if @announcement.update(announcement_params)
+        redirect_to :admin_announcements
+      else
+        fill_links!
+        render :edit
+      end
+    end
+
+    def destroy
+      @announcement.destroy
+      redirect_to admin_announcements_path
+    end
+
+    private
+
+    def set_announcement
+      @announcement = Announcement.find(params[:id])
+    end
+
+    def announcement_params
+      params.require(:announcement).permit(:body, :order, links_attributes: [:id, :text, :url]).tap do |x|
+        x[:links_attributes].each do |n, link|
+          link[:_destroy] = 1 if link[:id].present? && link[:url].blank? && link[:text].blank?
+        end
+      end
+    end
+
+    def fill_links!
+      @announcement.links << (3 - @announcement.links.length).times.map { AnnouncementLink.new }
+    end
+
+    def publish_updates
+      AnnouncementPublishWorker.perform_async
+    end
+  end
+end

--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -1,0 +1,8 @@
+export const TOGGLE_ANNOUNCEMENTS = 'TOGGLE_ANNOUNCEMENTS';
+export const UPDATE_ANNOUNCEMENTS = 'UPDATE_ANNOUNCEMENTS';
+
+export function toggleAnnouncements() {
+  return {
+    type: TOGGLE_ANNOUNCEMENTS,
+  };
+};

--- a/app/javascript/mastodon/actions/commands.js
+++ b/app/javascript/mastodon/actions/commands.js
@@ -1,0 +1,19 @@
+import { connectStream } from '../stream';
+import { UPDATE_ANNOUNCEMENTS } from './announcements';
+
+export function connectCommandStream(pollingRefresh = null) {
+  return connectStream('commands', pollingRefresh, (dispatch) => ({
+    onReceive(data) {
+      switch(data.event) {
+      case 'announcements':
+        dispatch({
+          type: UPDATE_ANNOUNCEMENTS,
+          data: JSON.parse(data.payload),
+        });
+        break;
+      default:
+        return;
+      }
+    },
+  }));
+}

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -11,6 +11,7 @@ import { connectUserStream } from '../actions/streaming';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import { getLocale } from '../locales';
 import initialState from '../initial_state';
+import { connectCommandStream } from '../actions/commands';
 
 const { localeData, messages } = getLocale();
 addLocaleData(localeData);
@@ -27,6 +28,7 @@ export default class Mastodon extends React.PureComponent {
 
   componentDidMount() {
     this.disconnect = store.dispatch(connectUserStream());
+    this.commandDisconnect = store.dispatch(connectCommandStream());
 
     // Desktop notifications
     // Ask after 1 minute
@@ -48,6 +50,10 @@ export default class Mastodon extends React.PureComponent {
     if (this.disconnect) {
       this.disconnect();
       this.disconnect = null;
+    }
+    if (this.commandDisconnect) {
+      this.commandDisconnect();
+      this.commandDisconnect = null;
     }
   }
 

--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -1,96 +1,59 @@
 import React from 'react';
-import Immutable from 'immutable';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { FormattedMessage } from 'react-intl';
 import Link from 'react-router-dom/Link';
-import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from '../../../components/announcement_icon_button';
 import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 
-const Collapsable = ({ fullHeight, minHeight, isVisible, children }) => (
-  <Motion defaultStyle={{ height: isVisible ? fullHeight : minHeight }} style={{ height: spring(!isVisible ? minHeight : fullHeight) }}>
-    {({ height }) =>
-      <div style={{ height: `${height}px`, overflow: 'hidden' }}>
-        {children}
-      </div>
-    }
-  </Motion>
-);
-
-Collapsable.propTypes = {
-  fullHeight: PropTypes.number.isRequired,
-  minHeight: PropTypes.number.isRequired,
-  isVisible: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired,
-};
-
-const messages = defineMessages({
-  toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
-  welcome: { id: 'welcome.message', defaultMessage: 'Welcome to {domain}!' },
-});
-
-const hashtags = Immutable.fromJS([
-  'Pの自己紹介',
-  'みんなのP名刺',
-]);
-
-class Announcements extends React.PureComponent {
+export default class Announcements extends React.PureComponent {
 
   static propTypes = {
-    intl: PropTypes.object.isRequired,
-    homeSize: PropTypes.number,
-    isLoading: PropTypes.bool,
+    visible: PropTypes.bool.isRequired,
+    onToggle: PropTypes.func.isRequired,
+    announcements: ImmutablePropTypes.list.isRequired,
   };
-
-  state = {
-    show: false,
-    isLoaded: false,
-  };
-
-  onClick = () => {
-    this.setState({ show: !this.state.show });
-  }
-  nl2br (text) {
-    return text.split(/(\n)/g).map((line, i) => {
-      if (line.match(/(\n)/g)) {
-        return React.createElement('br', { key: i });
-      }
-      return line;
-    });
-  }
 
   render () {
-    const { intl } = this.props;
+    const { visible, onToggle, announcements } = this.props;
+    const caretClass = visible ? 'fa fa-caret-down' : 'fa fa-caret-up';
 
     return (
-      <ul className='announcements'>
-        <li>
-          <Collapsable isVisible={this.state.show} fullHeight={300} minHeight={20} >
-            <div className='announcements__body'>
-              <p>{ this.nl2br(intl.formatMessage(messages.welcome, { domain: document.title }))}</p>
-              {hashtags.map((hashtag, i) =>
-                <Link key={i} to={`/timelines/tag/${hashtag}`} tabIndex={this.state.show ? undefined : -1}>
-                  #{hashtag}
-                </Link>
-              )}
-            </div>
-          </Collapsable>
-          <div className='announcements__icon'>
-            <IconButton title={intl.formatMessage(messages.toggle_visible)} icon='caret-up' onClick={this.onClick} size={20} animate active={this.state.show} />
-          </div>
-        </li>
-      </ul>
+      <div className='announcements'>
+        <div className='compose__extra__header'>
+          <i className='fa fa-bell' />
+            <FormattedMessage id='announcement.title' defaultMessage='information' />
+          <button className='compose__extra__header__icon' onClick={onToggle} >
+            <i className={caretClass} />
+          </button>
+        </div>
+        { visible && (
+          <ul>
+            {announcements.map((announcement, idx) => (
+              <li key={idx}>
+                <div className='announcements__body'>
+                  <p dangerouslySetInnerHTML={{ __html: announcement.get('body') }} />
+                  <div className='links'>
+                    {announcement.get('links').map((link, i) => {
+                      if (link.get('url').indexOf('/') === 0) {
+                        return (
+                          <Link to={link.get('url')} key={i}>{link.get('text')}</Link>
+                        );
+                      } else {
+                        return (
+                          <a href={link.get('url')} target='_blank' key={i}>{link.get('text')}</a>
+                        );
+                      }
+                    })}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     );
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (!this.state.isLoaded) {
-      if (!nextProps.isLoading && (nextProps.homeSize === 0 || this.props.homeSize !== nextProps.homeSize)) {
-        this.setState({ show: nextProps.homeSize < 5, isLoaded: true });
-      }
-    }
-  }
-
 }
-
-export default injectIntl(Announcements);

--- a/app/javascript/mastodon/features/compose/components/announcements.js
+++ b/app/javascript/mastodon/features/compose/components/announcements.js
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
 import Link from 'react-router-dom/Link';
-import IconButton from '../../../components/announcement_icon_button';
-import Motion from 'react-motion/lib/Motion';
-import spring from 'react-motion/lib/spring';
 
 export default class Announcements extends React.PureComponent {
 
@@ -23,7 +20,7 @@ export default class Announcements extends React.PureComponent {
       <div className='announcements'>
         <div className='compose__extra__header'>
           <i className='fa fa-bell' />
-            <FormattedMessage id='announcement.title' defaultMessage='information' />
+          <FormattedMessage id='announcement.title' defaultMessage='information' />
           <button className='compose__extra__header__icon' onClick={onToggle} >
             <i className={caretClass} />
           </button>

--- a/app/javascript/mastodon/features/compose/containers/announcements_container.js
+++ b/app/javascript/mastodon/features/compose/containers/announcements_container.js
@@ -1,11 +1,16 @@
 import { connect } from 'react-redux';
 import Announcements from '../components/announcements';
+import { toggleAnnouncements } from '../../../actions/announcements';
 
-const mapStateToProps = state => {
-  return {
-    homeSize: state.getIn(['timelines', 'home', 'items']).size,
-    isLoading: state.getIn(['timelines', 'home', 'isLoading']),
-  };
-};
+const mapStateToProps = (state) => ({
+  visible: state.getIn(['announcements', 'visible']),
+  announcements: state.getIn(['announcements', 'list']),
+});
 
-export default connect(mapStateToProps)(Announcements);
+const mapDispatchToProps = (dispatch) => ({
+  onToggle () {
+    dispatch(toggleAnnouncements());
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Announcements);

--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -9,7 +9,7 @@ const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\S+)/i;
 
 const mapStateToProps = state => ({
   needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: ['private','direct'].includes(state.getIn(['compose', 'privacy'])) && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
+  hashtagWarning: ['private', 'direct'].includes(state.getIn(['compose', 'privacy'])) && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
 });
 
 const WarningWrapper = ({ needsLockWarning, hashtagWarning }) => {

--- a/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = dispatch => ({
   addFavouriteTags (tag, visibility) {
     dispatch(addFavouriteTags(tag, visibility));
   },
-  
+
   removeFavouriteTags (tag) {
     dispatch(removeFavouriteTags(tag));
   },

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -493,8 +493,8 @@
   {
     "descriptors": [
       {
-        "defaultMessage": "Welcome to {domain}!",
-        "id": "welcome.message"
+        "defaultMessage": "Information",
+        "id": "announcement.title"
       }
     ],
     "path": "app/javascript/mastodon/features/compose/components/announcements.json"

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -24,6 +24,7 @@
   "account.unmute": "Unmute @{name}",
   "account.unmute_notifications": "Unmute notifications from @{name}",
   "account.view_full_profile": "View full profile",
+  "announcement.title": "Information",
   "boost_modal.combo": "You can press {combo} to skip this next time",
   "bundle_column_error.body": "Something went wrong while loading this component.",
   "bundle_column_error.retry": "Try again",
@@ -260,6 +261,5 @@
   "video.mute": "Mute sound",
   "video.pause": "Pause",
   "video.play": "Play",
-  "video.unmute": "Unmute sound",
-  "welcome.message": "Welcome to {domain}!\n\nLet's search followers by using lower hashtags."
+  "video.unmute": "Unmute sound"
 }

--- a/app/javascript/mastodon/locales/ja-IM.json
+++ b/app/javascript/mastodon/locales/ja-IM.json
@@ -24,6 +24,7 @@
   "account.unmute": "もう一度話を聞く",
   "account.unmute_notifications": "@{name}さんからの通知を受け取らない",
   "account.view_full_profile": "全ての情報を見る",
+  "announcement.title": "お知らせ",
   "boost_modal.combo": "次からは{combo}を押せば、これをスキップできます",
   "bundle_column_error.body": "コンポーネントの読み込み中に問題が発生しました。",
   "bundle_column_error.retry": "再試行",
@@ -269,6 +270,5 @@
   "video.mute": "ミュート",
   "video.pause": "一時停止",
   "video.play": "再生",
-  "video.unmute": "ミュートを解除する",
-  "welcome.message": "初めましての方へ\n\nいらっしゃいませ。{domain}は全てのアイマスを歓迎します。ローカルタイムラインで話に乗るもよし、まったく関係ない発言をするもよし。ぜひ、概ねアイマスの話しか流れてこないこのサーバを楽しんでください。\n\nフォローしたい人を探すにあたっては、下記のタグが参考になるでしょう。"
+  "video.unmute": "ミュートを解除する"
 }

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -24,6 +24,7 @@
   "account.unmute": "ミュート解除",
   "account.unmute_notifications": "@{name}さんからの通知を受け取らない",
   "account.view_full_profile": "全ての情報を見る",
+  "announcement.title": "お知らせ",
   "boost_modal.combo": "次からは{combo}を押せば、これをスキップできます",
   "bundle_column_error.body": "コンポーネントの読み込み中に問題が発生しました。",
   "bundle_column_error.retry": "再試行",
@@ -269,6 +270,5 @@
   "video.mute": "ミュート",
   "video.pause": "一時停止",
   "video.play": "再生",
-  "video.unmute": "ミュートを解除する",
-  "welcome.message": "初めましての方へ\n\nいらっしゃいませ。{domain}は全てのアイマスを歓迎します。ローカルタイムラインで話に乗るもよし、まったく関係ない発言をするもよし。ぜひ、概ねアイマスの話しか流れてこないこのサーバを楽しんでください。\n\nフォローしたい人を探すにあたっては、下記のタグが参考になるでしょう。"
+  "video.unmute": "ミュートを解除する"
 }

--- a/app/javascript/mastodon/reducers/announcements.js
+++ b/app/javascript/mastodon/reducers/announcements.js
@@ -1,0 +1,24 @@
+import { STORE_HYDRATE } from '../actions/store';
+import Immutable from 'immutable';
+import {
+  TOGGLE_ANNOUNCEMENTS,
+  UPDATE_ANNOUNCEMENTS,
+} from '../actions/announcements';
+
+const initialState = Immutable.Map({
+  visible: true,
+  list: Immutable.List(),
+});
+
+export default function announcements(state = initialState, action) {
+  switch(action.type) {
+  case STORE_HYDRATE:
+    return state.set('list', action.state.get('announcements'));
+  case UPDATE_ANNOUNCEMENTS:
+    return state.set('list', Immutable.fromJS(action.data));
+  case TOGGLE_ANNOUNCEMENTS:
+    return state.set('visible', !state.get('visible'));
+  default:
+    return state;
+  }
+};

--- a/app/javascript/mastodon/reducers/index.js
+++ b/app/javascript/mastodon/reducers/index.js
@@ -17,6 +17,7 @@ import mutes from './mutes';
 import reports from './reports';
 import contexts from './contexts';
 import favourite_tags from './favourite_tags';
+import announcements from './announcements';
 import compose from './compose';
 import search from './search';
 import media_attachments from './media_attachments';
@@ -46,6 +47,7 @@ const reducers = {
   reports,
   contexts,
   favourite_tags,
+  announcements,
   compose,
   search,
   media_attachments,

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id         :integer          not null, primary key
+#  body       :string           default(""), not null
+#  order      :integer          default(0), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Announcement < ApplicationRecord
+  has_many :links, class_name: 'AnnouncementLink', inverse_of: :announcement
+
+  accepts_nested_attributes_for :links, reject_if: proc { |attrs| attrs['url'].blank? && attrs['text'].blank? }, allow_destroy: true
+  default_scope { includes(:links).order(order: :desc) }
+
+  validates :body, presence: true
+end

--- a/app/models/announcement_link.rb
+++ b/app/models/announcement_link.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: announcement_links
+#
+#  id              :integer          not null, primary key
+#  announcement_id :integer          not null
+#  text            :string           default(""), not null
+#  url             :string           default(""), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+class AnnouncementLink < ApplicationRecord
+  belongs_to :announcement, inverse_of: :links
+
+  validates :text, presence: true
+  validates :url, presence: true
+end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -5,6 +5,7 @@ class InitialStateSerializer < ActiveModel::Serializer
              :media_attachments, :settings, :push_subscription
 
   has_many :custom_emojis, serializer: REST::CustomEmojiSerializer
+  has_many :announcements, serializer: REST::AnnouncementSerializer
 
   def custom_emojis
     CustomEmoji.local.where(disabled: false)
@@ -57,5 +58,9 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   def media_attachments
     { accept_content_types: MediaAttachment::IMAGE_FILE_EXTENSIONS + MediaAttachment::VIDEO_FILE_EXTENSIONS + MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES }
+  end
+
+  def announcements
+    Announcement.all
   end
 end

--- a/app/serializers/rest/announcement_link_serializer.rb
+++ b/app/serializers/rest/announcement_link_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class REST::AnnouncementLinkSerializer < ActiveModel::Serializer
+  attributes :url, :text
+end

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class REST::AnnouncementSerializer < ActiveModel::Serializer
+  attributes :id, :body
+  has_many :links, serializer: REST::AnnouncementLinkSerializer
+end

--- a/app/views/admin/announcements/_form.html.haml
+++ b/app/views/admin/announcements/_form.html.haml
@@ -1,0 +1,16 @@
+= simple_form_for [:admin, @announcement] do |f|
+  = render 'shared/error_messages', object: @announcement
+
+  = f.input :body, placeholder: t('admin.announcements.body'), as: :text, hint: t('.hint.body'), input_html: { rows: 4 }
+  = f.input :order, wrapper: :with_label, as: :integer, hint: t('.hint.order'), label: t('admin.announcements.order')
+
+  %h3= t('admin.announcements.links')
+  = f.fields_for :links do |ff|
+    .fields-group
+      = ff.input :id, as: :hidden
+      = ff.input :text, wrapper: :with_label, as: :string, label: t('.links.text')
+      = ff.input :url, wrapper: :with_label, as: :string, label: t('.links.url')
+    %hr
+
+  .actions
+    = f.button :button, submit, type: :submit

--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -1,0 +1,4 @@
+- content_for :page_title do
+  = t('.title')
+
+= render 'form', submit: t('.submit')

--- a/app/views/admin/announcements/index.html.haml
+++ b/app/views/admin/announcements/index.html.haml
@@ -1,0 +1,22 @@
+- content_for :page_title do
+  = t('admin.announcements.title')
+
+= link_to t('admin.announcements.add_new'), new_admin_announcement_path, class: 'button'
+
+%table.table
+  %thead
+    %tr
+      %th= t('admin.announcements.order')
+      %th= t('admin.announcements.body')
+      %th= t('admin.announcements.links')
+  %tbody
+    - @announcements.each do |announcement|
+      %tr
+        %td= announcement.order
+        %td= announcement.body
+        %td
+          - announcement.links.each do |link|
+            = link_to link.text, link.url, class: 'text'
+        %td
+          = table_link_to 'edit', t('admin.announcements.edit_it'), edit_admin_announcement_path(announcement)
+          = table_link_to 'trash', t('admin.announcements.delete_it'), admin_announcement_path(announcement), method: :delete

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -1,0 +1,4 @@
+- content_for :page_title do
+  = t('.title')
+
+= render 'form', submit: t('.submit')

--- a/app/workers/announcement_publish_worker.rb
+++ b/app/workers/announcement_publish_worker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AnnouncementPublishWorker
+  include Sidekiq::Worker
+
+  def perform
+    @announcements = Announcement.all
+    resources = ActiveModelSerializers::SerializableResource.new(@announcements, each_serializer: REST::AnnouncementSerializer)
+    Redis.current.publish('commands', Oj.dump(event: 'announcements', payload: resources))
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,27 @@ en:
         update_custom_emoji: "%{name} updated emoji %{target}"
         update_status: "%{name} updated status by %{target}"
       title: Audit log
+    announcements:
+      add_new: Add new
+      body: Announcement body. You can use HTML tags
+      delete_it: Delete
+      edit:
+        submit: Update announcement
+        title: Edit announcement
+      edit_it: Edit
+      form:
+        hint:
+          body: Linebrake will be ignored.
+          order: Descending order
+        links:
+          text: Link text
+          url: URL
+      links: Links
+      new:
+        submit: Create announcement
+        title: Add new announcement
+      order: Order
+      title: Announcement
     custom_emojis:
       by_domain: Domain
       copied_msg: Successfully created local copy of the emoji

--- a/config/locales/ja-IM.yml
+++ b/config/locales/ja-IM.yml
@@ -160,6 +160,27 @@ ja-IM:
         update_custom_emoji: "%{name} さんがカスタム絵文字 %{target} を更新しました"
         update_status: "%{name} さんが %{target} さんのあふぅを更新しました"
       title: 操作履歴
+    announcements:
+      add_new: 新規追加
+      body: 本文。HTMLタグが使えます
+      delete_it: 削除
+      edit:
+        submit: お知らせを変更
+        title: お知らせの編集
+      edit_it: 編集
+      form:
+        hint:
+          body: 改行は無視されます
+          order: 大きい順
+        links:
+          text: リンク文
+          url: URL
+      links: リンク
+      new:
+        submit: お知らせを作成
+        title: 新規お知らせの追加
+      order: 順序
+      title: お知らせ設定
     custom_emojis:
       by_domain: ドメイン
       copied_msg: 絵文字のコピーをローカルに作成しました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -160,6 +160,27 @@ ja:
         update_custom_emoji: "%{name} さんがカスタム絵文字 %{target} を更新しました"
         update_status: "%{name} さんが %{target} さんの投稿を更新しました"
       title: 操作履歴
+    announcements:
+      add_new: 新規追加
+      body: 本文。HTMLタグが使えます
+      delete_it: 削除
+      edit:
+        submit: お知らせを変更
+        title: お知らせの編集
+      edit_it: 編集
+      form:
+        hint:
+          body: 改行は無視されます
+          order: 大きい順
+        links:
+          text: リンク文
+          url: URL
+      links: リンク
+      new:
+        submit: お知らせを作成
+        title: 新規お知らせの追加
+      order: 順序
+      title: お知らせ設定
     custom_emojis:
       by_domain: ドメイン
       copied_msg: 絵文字のコピーをローカルに作成しました

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -35,6 +35,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
     primary.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), proc { current_user.admin? ? edit_admin_settings_url : admin_custom_emojis_url }, if: proc { current_user.staff? } do |admin|
       admin.item :settings, safe_join([fa_icon('cogs fw'), t('admin.settings.title')]), edit_admin_settings_url, if: -> { current_user.admin? }
+      admin.item :announcements, safe_join([fa_icon('cogs fw'), t('admin.announcements.title')]), admin_announcements_url
       admin.item :custom_emojis, safe_join([fa_icon('smile-o fw'), t('admin.custom_emojis.title')]), admin_custom_emojis_url, highlights_on: %r{/admin/custom_emojis}
       admin.item :subscriptions, safe_join([fa_icon('paper-plane-o fw'), t('admin.subscriptions.title')]), admin_subscriptions_url, if: -> { current_user.admin? }
       admin.item :sidekiq, safe_join([fa_icon('diamond fw'), 'Sidekiq']), sidekiq_url, link_html: { target: 'sidekiq' }, if: -> { current_user.admin? }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
     end
 
     resources :account_moderation_notes, only: [:create, :destroy]
+    resources :announcements, only: [:index, :new, :edit, :create, :update, :destroy]
   end
 
   authenticate :user, lambda { |u| u.admin? } do

--- a/db/migrate/20180122100118_create_announcements.rb
+++ b/db/migrate/20180122100118_create_announcements.rb
@@ -1,0 +1,12 @@
+class CreateAnnouncements < ActiveRecord::Migration[5.1]
+  def change
+    if ActiveRecord::Base.connection.table_exists? 'announcements'
+      drop_table :announcements
+    end
+    create_table :announcements do |t|
+      t.string :body, null: false, default: ''
+      t.integer :order, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180122110118_create_announcement_links.rb
+++ b/db/migrate/20180122110118_create_announcement_links.rb
@@ -1,0 +1,10 @@
+class CreateAnnouncementLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :announcement_links do |t|
+      t.references :announcement, foreign_key: { on_delete: :cascade }, null: false
+      t.string :text, null: false, default: ''
+      t.string :url, null: false, default: ''
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106000232) do
+ActiveRecord::Schema.define(version: 20180122110118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,22 @@ ActiveRecord::Schema.define(version: 20180106000232) do
     t.index ["target_type", "target_id"], name: "index_admin_action_logs_on_target_type_and_target_id"
   end
 
+  create_table "announcement_links", force: :cascade do |t|
+    t.bigint "announcement_id", null: false
+    t.string "text", default: "", null: false
+    t.string "url", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["announcement_id"], name: "index_announcement_links_on_announcement_id"
+  end
+
+  create_table "announcements", force: :cascade do |t|
+    t.string "body", default: "", null: false
+    t.integer "order", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "blocks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -146,11 +162,11 @@ ActiveRecord::Schema.define(version: 20180106000232) do
   end
 
   create_table "favourite_tags", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "visibility", default: 0, null: false
-    t.bigint "account_id", null: false
-    t.bigint "tag_id", null: false
     t.index ["account_id", "tag_id"], name: "index_favourite_tags_on_account_id_and_tag_id", unique: true
   end
 
@@ -525,6 +541,7 @@ ActiveRecord::Schema.define(version: 20180106000232) do
   add_foreign_key "account_moderation_notes", "accounts", column: "target_account_id"
   add_foreign_key "accounts", "accounts", column: "moved_to_account_id", on_delete: :nullify
   add_foreign_key "admin_action_logs", "accounts", on_delete: :cascade
+  add_foreign_key "announcement_links", "announcements", on_delete: :cascade
   add_foreign_key "blocks", "accounts", column: "target_account_id", name: "fk_9571bfabc1", on_delete: :cascade
   add_foreign_key "blocks", "accounts", name: "fk_4269e03e65", on_delete: :cascade
   add_foreign_key "conversation_mutes", "accounts", name: "fk_225b4212bb", on_delete: :cascade

--- a/spec/controllers/admin/announcements_controller_spec.rb
+++ b/spec/controllers/admin/announcements_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::AnnouncementsController, type: :controller do
+  let(:user) { Fabricate(:user, admin: true) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'PUT #update' do
+    let(:announcement) { Fabricate(:announcement) }
+    before do
+      Fabricate.times(2, :announcement_link, announcement: announcement)
+    end
+
+    it do
+      expect(announcement.links.length).to eq 2
+    end
+
+    it do
+      links = announcement.links.each_with_index.map do |link, i|
+        [i, {id: link.id, text: 'link', url: 'https://google.com' }]
+      end.to_h
+      put :update, params: { id: announcement.id, announcement: { body: 'hoge', links_attributes: links }}
+      expect(announcement.reload.links.length).to eq 2
+    end
+
+    it do
+      links = announcement.links.each_with_index.map do |link, i|
+        [i, { id: link.id, text: '', url: '' }]
+      end.to_h
+      put :update, params: { id: announcement.id, announcement: { body: 'hoge', links_attributes: links } }
+      expect(announcement.reload.links.length).to eq 0
+    end
+  end
+end

--- a/spec/fabricators/announcement_fabricator.rb
+++ b/spec/fabricators/announcement_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator(:announcement) do
+  body 'hello'
+end

--- a/spec/fabricators/announcement_link_fabricator.rb
+++ b/spec/fabricators/announcement_link_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:announcement_link) do
+  announcement
+  url 'https://google.com'
+  text 'google'
+end

--- a/spec/models/announcement_link_spec.rb
+++ b/spec/models/announcement_link_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AnnouncementLink, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Announcement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -535,6 +535,9 @@ const startWorker = (workerId) => {
         streamFrom(channel, req, streamToWs(req, ws), streamWsEnd(req, ws, subscriptionHeartbeat(channel)));
       });
       break;
+    case 'commands':
+      streamFrom('commands', req, streamToWs(req, ws), streamWsEnd(req, ws), false);
+      break;
     default:
       ws.close();
     }


### PR DESCRIPTION
https://github.com/dwango/mastodon/pull/197 のアップデートを移植しました。
管理画面にてお知らせandお知らせリンクの登録を行い、
ホーム画面にて表示を行います。

related #74 
