### PR TITLE
tagTLのstreaming APIについて、認証時にはpublicとunlistedを、未認証時にはpublicのみを配送するように変更

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -466,11 +466,23 @@ const startWorker = (workerId) => {
   });
 
   app.get('/api/v1/streaming/hashtag', (req, res) => {
-    streamFrom(`timeline:hashtag:${req.query.tag.toLowerCase()}`, req, streamToHttp(req, res), streamHttpEnd(req), true);
+    if (req.accountId) {
+      log.verbose(`timeline:hashtag:${req.query.tag.toLowerCase()}:authorized req.accountId: ${req.accountId}`);
+      streamFrom(`timeline:hashtag:${req.query.tag.toLowerCase()}:authorized`, req, streamToHttp(req, res), streamHttpEnd(req), true);
+    }else{
+      log.verbose(`timeline:hashtag:${req.query.tag.toLowerCase()} req.accountId: ${req.accountId}`);
+      streamFrom(`timeline:hashtag:${req.query.tag.toLowerCase()}`, req, streamToHttp(req, res), streamHttpEnd(req), true);
+    }
   });
 
   app.get('/api/v1/streaming/hashtag/local', (req, res) => {
-    streamFrom(`timeline:hashtag:${req.query.tag.toLowerCase()}:local`, req, streamToHttp(req, res), streamHttpEnd(req), true);
+    if (req.accountId) {
+      log.verbose(`timeline:hashtag:${req.query.tag.toLowerCase()}:authorized:local req.accountId: ${req.accountId}`);
+      streamFrom(`timeline:hashtag:${req.query.tag.toLowerCase()}:authorized:local`, req, streamToHttp(req, res), streamHttpEnd(req), true);
+    }else{
+      log.verbose(`timeline:hashtag:${req.query.tag.toLowerCase()}:local req.accountId: ${req.accountId}`);
+      streamFrom(`timeline:hashtag:${req.query.tag.toLowerCase()}:local`, req, streamToHttp(req, res), streamHttpEnd(req), true);
+    }
   });
 
   app.get('/api/v1/streaming/list', (req, res) => {
@@ -517,10 +529,22 @@ const startWorker = (workerId) => {
       streamFrom('timeline:public:local', req, streamToWs(req, ws), streamWsEnd(req, ws), true);
       break;
     case 'hashtag':
-      streamFrom(`timeline:hashtag:${location.query.tag.toLowerCase()}`, req, streamToWs(req, ws), streamWsEnd(req, ws), true);
+      if (req.accountId) {
+        log.verbose(`timeline:hashtag:${location.query.tag.toLowerCase()}:authorized req.accountId: ${req.accountId}`);
+        streamFrom(`timeline:hashtag:${location.query.tag.toLowerCase()}:authorized`, req, streamToWs(req, ws), streamWsEnd(req, ws), true);
+      }else{
+        log.verbose(`timeline:hashtag:${location.query.tag.toLowerCase()} req.accountId: ${req.accountId}`);
+        streamFrom(`timeline:hashtag:${location.query.tag.toLowerCase()}`, req, streamToWs(req, ws), streamWsEnd(req, ws), true);
+      }
       break;
     case 'hashtag:local':
-      streamFrom(`timeline:hashtag:${location.query.tag.toLowerCase()}:local`, req, streamToWs(req, ws), streamWsEnd(req, ws), true);
+      if (req.accountId) {
+        log.verbose(`timeline:hashtag:${location.query.tag.toLowerCase()}:authorized:local req.accountId: ${req.accountId}`);
+        streamFrom(`timeline:hashtag:${location.query.tag.toLowerCase()}:authorized:local`, req, streamToWs(req, ws), streamWsEnd(req, ws), true);
+      }else{
+        log.verbose(`timeline:hashtag:${location.query.tag.toLowerCase()}:local req.accountId: ${req.accountId}`);
+        streamFrom(`timeline:hashtag:${location.query.tag.toLowerCase()}:local`, req, streamToWs(req, ws), streamWsEnd(req, ws), true);
+      }
       break;
     case 'list':
       const listId = location.query.list;


### PR DESCRIPTION
表題通りです。

Server Side Eventsの場合もWebSocketの場合も
 https://github.com/imas/mastodon/blob/ccf4f170de86f24d5a243c411b807f1c394723cf/streaming/index.js#L219-L240 を通ります。

accountFromRequest関数はRequest headerまたはquery stringにtokenが指定されていた場合はエンドポイントが認証不要かどうかに関わらず https://github.com/imas/mastodon/blob/ccf4f170de86f24d5a243c411b807f1c394723cf/streaming/index.js#L188-L217 にてtokenの照会を行います。

accountFromToken関数は照会したtokenが正しいtokenだった場合に必ずreq.accountIdにそのtokenの所有者のaccountIdを代入するため、 https://github.com/imas/mastodon/blob/ccf4f170de86f24d5a243c411b807f1c394723cf/streaming/index.js#L468-L474 および https://github.com/imas/mastodon/blob/ccf4f170de86f24d5a243c411b807f1c394723cf/streaming/index.js#L519-L524 の時点ではreq.accountIdがundefinedかそうでないかによって認証の有無を判別することができます。

related #123