### PR TITLE
Enable showing trend tags on the WebUI

### DIFF
--- a/app/javascript/mastodon/actions/trend_tags.js
+++ b/app/javascript/mastodon/actions/trend_tags.js
@@ -1,6 +1,7 @@
 import api from '../api';
 
 export const TREND_TAGS_SUCCESS = 'TREND_TAGS_SUCCESS';
+export const TOGGLE_TREND_TAGS = 'TOGGLE_TREND_TAGS';
 
 export function refreshTrendTags() {
   return (dispatch, getState) => {
@@ -14,5 +15,11 @@ export function refreshTrendTagsSuccess(tags) {
   return {
     type: TREND_TAGS_SUCCESS,
     tags,
+  };
+}
+
+export function toggleTrendTags() {
+  return {
+    type: TOGGLE_TREND_TAGS,
   };
 }

--- a/app/javascript/mastodon/actions/trend_tags.js
+++ b/app/javascript/mastodon/actions/trend_tags.js
@@ -1,0 +1,18 @@
+import api from '../api';
+
+export const TREND_TAGS_SUCCESS = 'TREND_TAGS_SUCCESS';
+
+export function refreshTrendTags() {
+  return (dispatch, getState) => {
+    api(getState).get('/api/v1/trend_tags').then(response => {
+      dispatch(refreshTrendTagsSuccess(response.data));
+    });
+  };
+}
+
+export function refreshTrendTagsSuccess(tags) {
+  return {
+    type: TREND_TAGS_SUCCESS,
+    tags,
+  };
+}

--- a/app/javascript/mastodon/features/compose/components/trend_tags.js
+++ b/app/javascript/mastodon/features/compose/components/trend_tags.js
@@ -16,13 +16,14 @@ export default class TrendTags extends React.PureComponent {
 
   static propTypes = {
     intl: PropTypes.object.isRequired,
+    visible: PropTypes.bool.isRequired,
     trendTags: ImmutablePropTypes.map.isRequired,
     favouriteTags: ImmutablePropTypes.list.isRequired,
     refreshTrendTags: PropTypes.func.isRequired,
+    onToggle: PropTypes.func.isRequired,
   };
 
   state = {
-    show: true,
     animate: false,
   };
 
@@ -62,17 +63,13 @@ export default class TrendTags extends React.PureComponent {
     this.props.refreshTrendTags();
   }
 
-  onClickFold = () => {
-    this.setState({ show: !this.state.show });
-  }
-  
   onClickReload = () => {
     if (!this.state.animate) {
       this.setState({ animate: true });
       this.props.refreshTrendTags();
     }
   }
-  
+
   onAnimationEnd = () => {
     this.setState({ animate: false });
   }
@@ -80,15 +77,15 @@ export default class TrendTags extends React.PureComponent {
   isFavourited = (name) => {
     return this.props.favouriteTags.map(f => f.get('name').toLowerCase()).includes(name);
   }
-  
+
   reloadIcon = (isAnimate) => {
     return isAnimate ? <i className='fa fa-repeat animate' onAnimationEnd={this.onAnimationEnd} /> : <i className='fa fa-repeat' />;
   }
 
   render () {
-    const { intl } = this.props;
+    const { intl, visible, trendTags, onToggle } = this.props;
 
-    const tags = this.props.trendTags ? this.props.trendTags.keySeq().filter((v, k) => k < 5).map((name, index) => (
+    const tags = trendTags ? trendTags.keySeq().filter((v, k) => k < 5).map((name, index) => (
       <li key={name}>
         <div className='trend-tags__rank'>
           {index + 1}.
@@ -118,10 +115,10 @@ export default class TrendTags extends React.PureComponent {
             </a>
           </div>
           <div className='compose__extra__header__fold__icon'>
-            <FoldButton title={intl.formatMessage(messages.toggle_visible)} icon='caret-up' onClick={this.onClickFold} size={20} animate active={this.state.show} />
+            <FoldButton title={intl.formatMessage(messages.toggle_visible)} icon='caret-up' onClick={onToggle} size={20} animate active={visible} />
           </div>
         </div>
-        <Foldable isVisible={this.state.show} fullHeight={this.props.trendTags ? this.props.trendTags.size * 30 : 0} minHeight={0} >
+        <Foldable isVisible={visible} fullHeight={trendTags ? trendTags.size * 30 : 0} minHeight={0} >
           <ul className='compose__extra__body'>
             {tags}
           </ul>

--- a/app/javascript/mastodon/features/compose/components/trend_tags.js
+++ b/app/javascript/mastodon/features/compose/components/trend_tags.js
@@ -85,11 +85,8 @@ export default class TrendTags extends React.PureComponent {
   render () {
     const { intl, visible, trendTags, onToggle } = this.props;
 
-    const tags = trendTags ? trendTags.keySeq().filter((v, k) => k < 5).map((name, index) => (
+    const tags = trendTags ? trendTags.keySeq().filter((v, k) => k < 5).map(name => (
       <li key={name}>
-        <div className='trend-tags__rank'>
-          {index + 1}.
-        </div>
         <Link
           to={`/timelines/tag/${name}`}
           className='compose__extra__body__name'
@@ -119,9 +116,11 @@ export default class TrendTags extends React.PureComponent {
           </div>
         </div>
         <Foldable isVisible={visible} fullHeight={trendTags ? trendTags.size * 30 : 0} minHeight={0} >
-          <ul className='compose__extra__body'>
-            {tags}
-          </ul>
+          <div className='compose__extra__body'>
+            <ol>
+              {tags}
+            </ol>
+          </div>
         </Foldable>
       </div>
     );

--- a/app/javascript/mastodon/features/compose/components/trend_tags.js
+++ b/app/javascript/mastodon/features/compose/components/trend_tags.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Link from 'react-router-dom/Link';
+import PropTypes from 'prop-types';
+import { injectIntl, defineMessages } from 'react-intl';
+import FoldButton from '../../../components/fold_button';
+import Foldable from '../../../components/foldable';
+
+const messages = defineMessages({
+  trend_tags: { id: 'compose_form.trend_tags', defaultMessage: 'Trend tags' },
+  toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
+});
+
+@injectIntl
+export default class TrendTags extends React.PureComponent {
+
+  static propTypes = {
+    intl: PropTypes.object.isRequired,
+    trendTags: ImmutablePropTypes.map.isRequired,
+    favouriteTags: ImmutablePropTypes.list.isRequired,
+    refreshTrendTags: PropTypes.func.isRequired,
+  };
+
+  state = {
+    show: true,
+    animate: false,
+  };
+
+  componentDidMount() {
+    this.refresh();
+  }
+
+  componentWillUnmount() {
+    this.cancelPolling();
+  }
+
+  componentDidUpdate() {
+    this.setPolling();
+  }
+
+  setPolling = () => {
+    this.cancelPolling();
+    const now = new Date();
+    const min = now.getMinutes();
+    const sec = now.getSeconds();
+    let timeout = (610 - ((min + 5) % 10 * 60 + sec)) % 600 * 1000;
+    if (timeout === 0) {
+      timeout = 600 * 1000;
+    }
+    this.timer = setTimeout(this.refresh, timeout);
+  }
+
+  cancelPolling = () => {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  refresh = () => {
+    this.cancelPolling();
+    this.props.refreshTrendTags();
+  }
+
+  onClickFold = () => {
+    this.setState({ show: !this.state.show });
+  }
+  
+  onClickReload = () => {
+    if (!this.state.animate) {
+      this.setState({ animate: true });
+      this.props.refreshTrendTags();
+    }
+  }
+  
+  onAnimationEnd = () => {
+    this.setState({ animate: false });
+  }
+
+  isFavourited = (name) => {
+    return this.props.favouriteTags.map(f => f.get('name').toLowerCase()).includes(name);
+  }
+  
+  reloadIcon = (isAnimate) => {
+    return isAnimate ? <i className='fa fa-repeat animate' onAnimationEnd={this.onAnimationEnd} /> : <i className='fa fa-repeat' />;
+  }
+
+  render () {
+    const { intl } = this.props;
+
+    const tags = this.props.trendTags ? this.props.trendTags.keySeq().filter((v, k) => k < 5).map((name, index) => (
+      <li key={name}>
+        <div className='trend-tags__rank'>
+          {index + 1}.
+        </div>
+        <Link
+          to={`/timelines/tag/${name}`}
+          className='compose__extra__body__name'
+          key={name}
+        >
+          <i className='fa fa-hashtag' />
+          {name}
+        </Link>
+        <div className={`trend-tags__fav${this.isFavourited(name) ? ' active' : ''}`}>
+          <i className='fa fa-star' />
+        </div>
+      </li>
+    )) : null;
+
+    return (
+      <div className='compose__extra'>
+        <div className='compose__extra__header'>
+          <i className='fa fa-tag' />
+          <div className='compose__extra__header__name'>{intl.formatMessage(messages.trend_tags)}</div>
+          <div className='compose__extra__header__icon'>
+            <a href='javascript:void(0);' onClick={this.onClickReload} >
+              {this.reloadIcon(this.state.animate)}
+            </a>
+          </div>
+          <div className='compose__extra__header__fold__icon'>
+            <FoldButton title={intl.formatMessage(messages.toggle_visible)} icon='caret-up' onClick={this.onClickFold} size={20} animate active={this.state.show} />
+          </div>
+        </div>
+        <Foldable isVisible={this.state.show} fullHeight={this.props.trendTags ? this.props.trendTags.size * 30 : 0} minHeight={0} >
+          <ul className='compose__extra__body'>
+            {tags}
+          </ul>
+        </Foldable>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/containers/trend_tags_container.js
+++ b/app/javascript/mastodon/features/compose/containers/trend_tags_container.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import TrendTags from '../components/trend_tags';
+import { refreshTrendTags } from '../../../actions/trend_tags';
+
+const mapStateToProps = state => {
+  return {
+    trendTags: state.getIn(['trend_tags', 'tags', 'score']),
+    favouriteTags: state.getIn(['favourite_tags', 'tags']),
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  refreshTrendTags () {
+    dispatch(refreshTrendTags());
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TrendTags);

--- a/app/javascript/mastodon/features/compose/containers/trend_tags_container.js
+++ b/app/javascript/mastodon/features/compose/containers/trend_tags_container.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import TrendTags from '../components/trend_tags';
-import { refreshTrendTags } from '../../../actions/trend_tags';
+import { refreshTrendTags, toggleTrendTags } from '../../../actions/trend_tags';
 
 const mapStateToProps = state => {
   return {
     trendTags: state.getIn(['trend_tags', 'tags', 'score']),
+    visible: state.getIn(['trend_tags', 'visible']),
     favouriteTags: state.getIn(['favourite_tags', 'tags']),
   };
 };
@@ -12,6 +13,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   refreshTrendTags () {
     dispatch(refreshTrendTags());
+  },
+  onToggle () {
+    dispatch(toggleTrendTags());
   },
 });
 

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ComposeFormContainer from './containers/compose_form_container';
 import NavigationContainer from './containers/navigation_container';
 import FavouriteTagsContainer from './containers/favourite_tags_container';
+import TrendTagsContainer from './containers/trend_tags_container';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
@@ -100,6 +101,7 @@ export default class Compose extends React.PureComponent {
             <ComposeFormContainer />
             <AnnouncementsContainer />
             <FavouriteTagsContainer />
+            <TrendTagsContainer />
           </div>
 
           <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>

--- a/app/javascript/mastodon/reducers/index.js
+++ b/app/javascript/mastodon/reducers/index.js
@@ -17,6 +17,7 @@ import mutes from './mutes';
 import reports from './reports';
 import contexts from './contexts';
 import favourite_tags from './favourite_tags';
+import trend_tags from './trend_tags';
 import announcements from './announcements';
 import compose from './compose';
 import search from './search';
@@ -47,6 +48,7 @@ const reducers = {
   reports,
   contexts,
   favourite_tags,
+  trend_tags,
   announcements,
   compose,
   search,

--- a/app/javascript/mastodon/reducers/trend_tags.js
+++ b/app/javascript/mastodon/reducers/trend_tags.js
@@ -1,4 +1,4 @@
-import { TREND_TAGS_SUCCESS } from '../actions/trend_tags';
+import { TREND_TAGS_SUCCESS, TOGGLE_TREND_TAGS } from '../actions/trend_tags';
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
@@ -6,6 +6,7 @@ const initialState = Immutable.Map({
     updated_at: '',
     score: Immutable.Map(),
   }),
+  visible: true,
 });
 
 export default function trend_tags(state = initialState, action) {
@@ -13,8 +14,10 @@ export default function trend_tags(state = initialState, action) {
   case TREND_TAGS_SUCCESS:
     const tmp = Immutable.fromJS(action.tags);
     return state.set('tags', tmp.set('score', tmp.get('score').sort((a, b) => {
-      return b - a; 
+      return b - a;
     })));
+  case TOGGLE_TREND_TAGS:
+    return state.set('visible', !state.get('visible'));
   default:
     return state;
   }

--- a/app/javascript/mastodon/reducers/trend_tags.js
+++ b/app/javascript/mastodon/reducers/trend_tags.js
@@ -1,0 +1,21 @@
+import { TREND_TAGS_SUCCESS } from '../actions/trend_tags';
+import Immutable from 'immutable';
+
+const initialState = Immutable.Map({
+  tags: Immutable.Map({
+    updated_at: '',
+    score: Immutable.Map(),
+  }),
+});
+
+export default function trend_tags(state = initialState, action) {
+  switch(action.type) {
+  case TREND_TAGS_SUCCESS:
+    const tmp = Immutable.fromJS(action.tags);
+    return state.set('tags', tmp.set('score', tmp.get('score').sort((a, b) => {
+      return b - a; 
+    })));
+  default:
+    return state;
+  }
+}

--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -57,11 +57,31 @@
 }
 
 .compose__extra__body {
+  ol {
+    counter-reset: index;
+
+    li {
+      display: flex;
+      align-items: center;
+      padding: 6px 10px;
+      position: relative;
+
+      &:before {
+        counter-increment: index;
+        content: counter(index) ".";
+        font-size: 16px;
+        width: 15px;
+        padding: 0 5px;
+        text-align: center;
+      }
+    }
+  }
+
   li {
     display: flex;
     align-items: center;
     padding: 6px 10px;
-    position: relative
+    position: relative;
   }
 
   &__name {

--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -1,3 +1,12 @@
+@keyframes rotate_anime {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .compose__extra {
   background: $ui-base-color;
   position: relative;
@@ -30,6 +39,14 @@
 
     .fa-gear {
       color: $ui-primary-color;
+    }
+
+    .fa-repeat {
+      color: $ui-primary-color;
+
+      &.animate {
+        animation: rotate_anime 1s ease 0s 1 normal none;
+      }
     }
   }
 

--- a/app/javascript/styles/imastodon/trend_tags.scss
+++ b/app/javascript/styles/imastodon/trend_tags.scss
@@ -1,0 +1,25 @@
+
+/**
+  * features/compose/components/trend_tags
+  */
+
+.trend-tags__fav {
+  color: $ui-base-lighter-color;
+  position: absolute;
+  top: 50%;
+  right: 20px;
+  margin-top: -7px;
+  width: 14px;
+  text-align: center;
+
+  &.active {
+    color: $gold-star;
+  }
+}
+
+.trend-tags__rank {
+  font-size: 16px;
+  width: 15px;
+  padding: 0 5px;
+  text-align: center;
+}

--- a/app/javascript/styles/imastodon/trend_tags.scss
+++ b/app/javascript/styles/imastodon/trend_tags.scss
@@ -16,10 +16,3 @@
     color: $gold-star;
   }
 }
-
-.trend-tags__rank {
-  font-size: 16px;
-  width: 15px;
-  padding: 0 5px;
-  text-align: center;
-}

--- a/app/javascript/styles/theme_mastodon.scss
+++ b/app/javascript/styles/theme_mastodon.scss
@@ -5,4 +5,5 @@
 @import 'imastodon/favourite_tags';
 @import 'imastodon/getting_started';
 @import 'imastodon/statuses';
+@import 'imastodon/trend_tags';
 @import 'imastodon/tutorial';


### PR DESCRIPTION
Enable showing trend tags on the WebUI and make some changes for style sheets.
トレンドタグの集計結果をWebUI上に表示させます。伴ってスタイルシートをいくつか変更します。
![trend_tags_ui](https://user-images.githubusercontent.com/8458066/36206153-aa00c9de-11d4-11e8-835b-ff2d1da8f13f.gif)

トレンドタグリストは、上からスコア順に並べて最大上位5つまでを表示します。タグ名は当該タグのタグTLへのリンクになっています。お気に入りタグに登録されているタグの場合は右側の星マークがオレンジ色になります。

トレンドタグの更新は`setTimeout`を使用してトレンドタグ集計時間の10秒後に更新リクエストを送るようにしています。更新ボタンを手動でクリックしても更新できます。

~~従来、お気に入りタグリストでは長い（1行で表示できない）タグは折り返されて複数行で表示されていましたが、折り畳み式になると行数による高さの変更が難しくなるため、上の例のように1行に収まらない場合は省略するようにします。~~

~~ほとんど変わらないスタイルで複数の定義をしたくないので、スタイルシートは従来`favourite-tags__～～`となっていたものを可能な限り`compose__extra__～～`に変更し、composeカラムのextraなコンポーネントに共通で適用できるようにします。~~

~~共通のスタイルをannouncementsにも適用するかどうかは要検討かと思います。（他からの輸入なのでなるべく元のままがいい？）~~
2018/02/21
スタイル修正のPRは別に出したため訂正(#141) 

- [x] style共通化 #141 
- [ ] locale対応（特にIM@S語）