### PR TITLE
お気に入りタグに表示順カラム追加

### DIFF
--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   def find_or_init_tag
     Tag.find_or_initialize_by(name: tag_params[:tag])
   end
-  
+
   def find_tag
     Tag.find_by(name: tag_params[:tag])
   end
@@ -59,8 +59,8 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   def favourite_tag_visibility
     tag_params[:visibility].nil? ? 'public' : tag_params[:visibility]
   end
-  
+
   def current_favourite_tags
-    current_account.favourite_tags.order(:id).includes(:tag).map(&:to_json_for_api)
+    current_account.favourite_tags.order(:order).includes(:tag).map(&:to_json_for_api)
   end
 end

--- a/app/controllers/api/v1/favourite_tags_controller.rb
+++ b/app/controllers/api/v1/favourite_tags_controller.rb
@@ -61,6 +61,6 @@ class Api::V1::FavouriteTagsController < Api::BaseController
   end
 
   def current_favourite_tags
-    current_account.favourite_tags.order(:order).includes(:tag).map(&:to_json_for_api)
+    current_account.favourite_tags.with_order.includes(:tag).map(&:to_json_for_api)
   end
 end

--- a/app/controllers/settings/favourite_tags_controller.rb
+++ b/app/controllers/settings/favourite_tags_controller.rb
@@ -3,20 +3,34 @@ class Settings::FavouriteTagsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_account
   before_action :set_favourite_tags, only: [:index, :create]
-  before_action :set_favourite_tag, only: [:destroy]
+  before_action :set_favourite_tag, only: [:edit, :update, :destroy]
 
   def index
     @favourite_tag = FavouriteTag.new(tag: Tag.new, visibility: FavouriteTag.visibilities[:public])
   end
 
+  def edit
+    @favourite_tag
+  end
+
   def create
     name = tag_params[:name].gsub(/\A#/, '')
     tag = Tag.find_or_initialize_by(name: name)
-    @favourite_tag = FavouriteTag.new(account: @account, tag: tag, visibility: visibility_params[:visibility])
+    @favourite_tag = FavouriteTag.new(account: @account, tag: tag, visibility: favourite_tag_params[:visibility], order: favourite_tag_params[:order])
     if @favourite_tag.save
       redirect_to settings_favourite_tags_path, notice: I18n.t('generic.changes_saved_msg')
     else
       render :index
+    end
+  end
+
+  def update
+    name = tag_params[:name].gsub(/\A#/, '')
+    tag = Tag.find_or_initialize_by(name: name)
+    if @favourite_tag.update(tag: tag, visibility: favourite_tag_params[:visibility], order: favourite_tag_params[:order])
+      redirect_to settings_favourite_tags_path, notice: I18n.t('generic.changes_saved_msg')
+    else
+      render :edit
     end
   end
 
@@ -28,11 +42,11 @@ class Settings::FavouriteTagsController < ApplicationController
   private
 
   def tag_params
-    params.require(:favourite_tag).require(:tag_attributes).permit(:name)
+    params.require(:favourite_tag).require(:tag_attributes).permit(:id, :name)
   end
 
-  def visibility_params
-    params.require(:favourite_tag).permit(:visibility)
+  def favourite_tag_params
+    params.require(:favourite_tag).permit(:visibility, :order, { tag_attributes: [:id, :name] })
   end
 
   def set_account

--- a/app/controllers/settings/favourite_tags_controller.rb
+++ b/app/controllers/settings/favourite_tags_controller.rb
@@ -58,6 +58,6 @@ class Settings::FavouriteTagsController < ApplicationController
   end
 
   def set_favourite_tags
-    @favourite_tags = @account.favourite_tags.order(:order).includes(:tag)
+    @favourite_tags = @account.favourite_tags.with_order.includes(:tag)
   end
 end

--- a/app/controllers/settings/favourite_tags_controller.rb
+++ b/app/controllers/settings/favourite_tags_controller.rb
@@ -2,6 +2,7 @@ class Settings::FavouriteTagsController < ApplicationController
   layout 'admin'
   before_action :authenticate_user!
   before_action :set_account
+  before_action :set_favourite_tags, only: [:index, :create]
   before_action :set_favourite_tag, only: [:destroy]
 
   def index
@@ -40,5 +41,9 @@ class Settings::FavouriteTagsController < ApplicationController
 
   def set_favourite_tag
     @favourite_tag = @account.favourite_tags.find(params[:id])
+  end
+
+  def set_favourite_tags
+    @favourite_tags = @account.favourite_tags.order(:order).includes(:tag)
   end
 end

--- a/app/lib/friends/favourite_tags_extension.rb
+++ b/app/lib/friends/favourite_tags_extension.rb
@@ -13,8 +13,8 @@ module Friends
       ].freeze
 
       def add_default_favourite_tag
-        DEFAULT_TAGS.each do |tag_name|
-          self.favourite_tags.create!(visibility: 'public', tag: Tag.find_or_create_by!(name: tag_name))
+        DEFAULT_TAGS.each_with_index do |tag_name, i|
+          self.favourite_tags.create!(visibility: 'public', tag: Tag.find_or_create_by!(name: tag_name), order: i)
         end
       end
 

--- a/app/models/favourite_tag.rb
+++ b/app/models/favourite_tag.rb
@@ -21,6 +21,7 @@ class FavouriteTag < ApplicationRecord
 
   validates :tag, uniqueness: { scope: :account }
   validates :visibility, presence: true
+  validates :order, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   delegate :name, to: :tag
 

--- a/app/models/favourite_tag.rb
+++ b/app/models/favourite_tag.rb
@@ -8,6 +8,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  visibility :integer          default("public"), not null
+#  order      :integer          default(0), not null
 #
 
 class FavouriteTag < ApplicationRecord

--- a/app/models/favourite_tag.rb
+++ b/app/models/favourite_tag.rb
@@ -23,6 +23,8 @@ class FavouriteTag < ApplicationRecord
   validates :visibility, presence: true
   validates :order, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  scope :with_order, -> { order(order: :desc, id: :asc) }
+
   delegate :name, to: :tag
 
   def to_json_for_api

--- a/app/views/settings/favourite_tags/_form.html.haml
+++ b/app/views/settings/favourite_tags/_form.html.haml
@@ -1,0 +1,17 @@
+= simple_form_for [:settings, @favourite_tag] do |f|
+  = render 'shared/error_messages', object: @favourite_tag
+  = f.simple_fields_for :tag do |ff|
+    = ff.input :name, placeholder: t('favourite_tags.name_of_tag')
+  = f.input :visibility,
+    label: t('simple_form.labels.defaults.setting_default_privacy'),
+    collection: Status.visibilities.keys[0..1],
+    wrapper: :with_label,
+    include_blank: false,
+    label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), content_tag(:span, I18n.t("statuses.visibilities.#{visibility}_long"), class: 'hint')]) },
+    required: false,
+    as: :radio_buttons,
+    collection_wrapper_tag: 'ul',
+    item_wrapper_tag: 'li'
+  = f.input :order, wrapper: :with_label, as: :integer, hint: t('favourite_tags.form.hint.order'), label: t('favourite_tags.order')
+  .actions
+    = f.button :button, submit, type: :submit

--- a/app/views/settings/favourite_tags/edit.html.haml
+++ b/app/views/settings/favourite_tags/edit.html.haml
@@ -1,0 +1,4 @@
+- content_for :page_title do
+  = t('favourite_tags.edit.title')
+
+= render 'form', submit: t('favourite_tags.edit.submit')

--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -20,7 +20,7 @@
 
 %table.table
   %tbody
-    - current_account.favourite_tags.order(:id).includes(:tag).each do |fav_tag|
+    - @favourite_tags.each do |fav_tag|
       %tr
         %td
           = fa_icon 'tag'

--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -1,24 +1,17 @@
 - content_for :page_title do
   = t('settings.favourite_tags')
 
-= simple_form_for @favourite_tag, url: settings_favourite_tags_url do |f|
-  = render 'shared/error_messages', object: @favourite_tag
-  = f.simple_fields_for :tag do |ff|
-    = ff.input :name, placeholder: t('favourite_tags.name_of_tag')
-  = f.input :visibility,
-    label: t('simple_form.labels.defaults.setting_default_privacy'),
-    collection: Status.visibilities.keys[0..1],
-    wrapper: :with_label,
-    include_blank: false,
-    label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), content_tag(:span, I18n.t("statuses.visibilities.#{visibility}_long"), class: 'hint')]) },
-    required: false,
-    as: :radio_buttons,
-    collection_wrapper_tag: 'ul',
-    item_wrapper_tag: 'li'
-  = f.button :button, type: 'submit'
+= render 'form', submit: t('favourite_tags.submit')
 %hr
 
 %table.table
+  %thead
+    %tr
+      %th= t('favourite_tags.name_of_tag')
+      %th= t('simple_form.labels.defaults.setting_default_privacy')
+      %th= t('favourite_tags.order')
+      %th= t('favourite_tags.edit_it')
+      %th= t('favourite_tags.delete_it')
   %tbody
     - @favourite_tags.each do |fav_tag|
       %tr
@@ -28,4 +21,8 @@
         %td
           = I18n.t("statuses.visibilities.#{fav_tag.visibility}")
         %td
-          = table_link_to 'trash', t('favourite_tags.delete'), settings_favourite_tag_path(fav_tag), method: :delete
+          = fav_tag.order
+        %td
+          = table_link_to 'edit', '', edit_settings_favourite_tag_path(fav_tag)
+        %td
+          = table_link_to 'trash', '', settings_favourite_tag_path(fav_tag), method: :delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -448,7 +448,7 @@ en:
     edit_it: edit
     form:
       hint:
-        order: Display in ascending order
+        order: Display in descending order
     name_of_tag: Name of tag
     order: order
     submit: Create favourite tag

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,8 +441,17 @@ en:
     mutes: You mute
     storage: Media storage
   favourite_tags:
-    delete: delete
+    delete_it: delete
+    edit:
+      submit: Update favourite tag
+      title: Edit favourite tag
+    edit_it: edit
+    form:
+      hint:
+        order: Display in ascending order
     name_of_tag: Name of tag
+    order: order
+    submit: Create favourite tag
   followers:
     domain: Domain
     explanation_html: If you want to ensure the privacy of your statuses, you must be aware of who is following you. <strong>Your private statuses are delivered to all instances where you have followers</strong>. You may wish to review them, and remove followers if you do not trust your privacy to be respected by the staff or software of those instances.

--- a/config/locales/ja-IM.yml
+++ b/config/locales/ja-IM.yml
@@ -441,8 +441,17 @@ ja-IM:
     mutes: だまっとけ☆
     storage: メディア
   favourite_tags:
-    delete: 削除
+    delete_it: 削除
+    edit:
+      submit: お気に入りタグを変更
+      title: お気に入りタグの編集
+    edit_it: 編集
+    form:
+      hint:
+        order: 昇順に表示されます
     name_of_tag: タグ名
+    order: 順序
+    submit: お気に入りタグを登録
   followers:
     domain: ドメイン
     explanation_html: あなたのあふぅのプライバシーを確保したい場合、誰があなたをフォローしているのかを把握している必要があります。 <strong>プライベートあふぅは、あなたのフォロワーがいる全てのインスタンスに配信されます</strong>。 フォロワーのインスタンスの管理者やソフトウェアがあなたのプライバシーを尊重してくれるかどうか怪しい場合は、そのフォロワーを削除した方がよいかもしれません。

--- a/config/locales/ja-IM.yml
+++ b/config/locales/ja-IM.yml
@@ -448,7 +448,7 @@ ja-IM:
     edit_it: 編集
     form:
       hint:
-        order: 昇順に表示されます
+        order: 降順に表示されます
     name_of_tag: タグ名
     order: 順序
     submit: お気に入りタグを登録

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -448,7 +448,7 @@ ja:
     edit_it: 編集
     form:
       hint:
-        order: 昇順に表示されます
+        order: 降順に表示されます
     name_of_tag: タグ名
     order: 順序
     submit: お気に入りタグを登録

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -441,8 +441,17 @@ ja:
     mutes: ミュート
     storage: メディア
   favourite_tags:
-    delete: 削除
+    delete_it: 削除
+    edit:
+      submit: お気に入りタグを変更
+      title: お気に入りタグの編集
+    edit_it: 編集
+    form:
+      hint:
+        order: 昇順に表示されます
     name_of_tag: タグ名
+    order: 順序
+    submit: お気に入りタグを登録
   followers:
     domain: ドメイン
     explanation_html: あなたの投稿のプライバシーを確保したい場合、誰があなたをフォローしているのかを把握している必要があります。 <strong>プライベート投稿は、あなたのフォロワーがいる全てのインスタンスに配信されます</strong>。 フォロワーのインスタンスの管理者やソフトウェアがあなたのプライバシーを尊重してくれるかどうか怪しい場合は、そのフォロワーを削除した方がよいかもしれません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
     end
 
     resource :delete, only: [:show, :destroy]
-    resources :favourite_tags, only: [:index, :create, :destroy]
+    resources :favourite_tags, only: [:index, :edit, :create, :update, :destroy]
     resource :migration, only: [:show, :update]
 
     resources :sessions, only: [:destroy]

--- a/db/migrate/20180213223419_add_order_to_favourite_tags.rb
+++ b/db/migrate/20180213223419_add_order_to_favourite_tags.rb
@@ -1,0 +1,20 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddOrderToFavouriteTags < ActiveRecord::Migration[5.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column_with_default :favourite_tags, :order, :integer, default: 0, allow_null: false
+    end
+  end
+
+  def down
+    remove_column :favourite_tags, :order
+  end
+end
+
+# execute update
+# update favourite_tags set order = temp.rnum from (select f.id, f.account_id, row_number() OVER (PARTITION BY f.account_id ORDER BY f.id) AS rnum from favourite_tags as f group by f.account_id, f.id order by f.id) as temp where favourite_tags.id = temp.id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180122110118) do
+ActiveRecord::Schema.define(version: 20180213223419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,7 @@ ActiveRecord::Schema.define(version: 20180122110118) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "visibility", default: 0, null: false
+    t.integer "order", default: 0, null: false
     t.index ["account_id", "tag_id"], name: "index_favourite_tags_on_account_id_and_tag_id", unique: true
   end
 

--- a/spec/controllers/settings/favourite_tags_controller_spec.rb
+++ b/spec/controllers/settings/favourite_tags_controller_spec.rb
@@ -22,6 +22,36 @@ RSpec.describe Settings::FavouriteTagsController, type: :controller do
     end
   end
 
+  describe 'GET #edit' do
+    let(:tag) { Fabricate(:tag, name: 'dummy_tag') }
+    let!(:favourite_tag) { Fabricate(:favourite_tag, account: @user.account, tag: tag) }
+
+    context 'when the favourite tag is found.' do
+      before do
+        get :edit, params: { id: favourite_tag.id }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'assigns @favourite_tag' do
+        expect(assigns(:favourite_tag)).to be_kind_of FavouriteTag
+        expect(assigns(:favourite_tag)).to eq(favourite_tag)
+      end
+    end
+
+    context 'when the favourite tag is not found.' do
+      before do
+        get :edit, params: { id: 0 }
+      end
+
+      it 'returns not found status' do
+        expect(response).to have_http_status(:missing)
+      end
+    end
+  end
+
   describe 'POST #create' do
     let(:tag_name) { 'dummy_tag' }
     let(:params) {
@@ -30,7 +60,8 @@ RSpec.describe Settings::FavouriteTagsController, type: :controller do
           tag_attributes: {
             name: tag_name
           },
-          visibility: 'public'
+          visibility: 'public',
+          order: 1
         }
       }
     }
@@ -60,17 +91,80 @@ RSpec.describe Settings::FavouriteTagsController, type: :controller do
     end
   end
 
+  describe 'PUT #update' do
+    let(:tag) { Fabricate(:tag, name: 'dummy_tag') }
+    let!(:favourite_tag) { Fabricate(:favourite_tag, account: @user.account, tag: tag) }
+
+    context 'The favourite tag can update.' do
+      let(:params) {
+        {
+          id: favourite_tag.id,
+          favourite_tag: {
+            tag_attributes: {
+              name: 'dummy_tag_' + favourite_tag.id.to_s
+            },
+            visibility: 'unlisted',
+            order: 2
+          }
+        }
+      }
+
+      subject { put :update, params: params }
+
+      it 'after update, tag' do
+        expect { subject }.to change { Tag.count }.by(1)
+        expect(assigns(:favourite_tag).tag.name).not_to eq('dummy_tag')
+        expect(response).to redirect_to(settings_favourite_tags_path)
+      end
+
+      it 'after update, favourite tag' do
+        expect { subject }.not_to change(FavouriteTag, :count)
+        expect(assigns(:favourite_tag).visibility).to eq('unlisted')
+        expect(assigns(:favourite_tag).order).to eq(2)
+        expect(response).to redirect_to(settings_favourite_tags_path)
+      end
+    end
+
+    context 'The favourite tag could not update, because tag has already been registered.' do
+      let(:tag_name) { 'dummy_tag2' }
+      let(:params) {
+        {
+          id: favourite_tag.id,
+          favourite_tag: {
+            tag_attributes: {
+              name: tag_name
+            },
+            visibility: 'unlisted',
+            order: 2
+          }
+        }
+      }
+      let(:tag2) { Fabricate(:tag, name: tag_name) }
+
+      subject { put :update, params: params }
+
+      before do
+        Fabricate(:favourite_tag, account: @user.account, tag: tag2)
+      end
+
+      it 'should not update any tags and should render edit template' do
+        expect { subject }.not_to change(Tag, :count)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
   describe 'DELETE #destroy' do
     let(:tag) { Fabricate(:tag, name: 'dummy_tag') }
     let!(:favourite_tag) { Fabricate(:favourite_tag, account: @user.account, tag: tag) }
     let(:params) {
       {
         id: favourite_tag.id
-      } 
+      }
     }
 
     subject { delete :destroy, params: params }
-    
+
     it 'after destroy, tag' do
       expect { subject }.not_to change(Tag, :count)
       expect(response).to redirect_to(settings_favourite_tags_path)

--- a/spec/fabricators/favourite_tags_fabricator.rb
+++ b/spec/fabricators/favourite_tags_fabricator.rb
@@ -2,4 +2,5 @@ Fabricator(:favourite_tag) do
   account
   tag
   visibility 0
+  order 0
 end

--- a/spec/models/favourite_tags_spec.rb
+++ b/spec/models/favourite_tags_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe FavouriteTag, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe 'with_order' do
+      let(:account) { Fabricate(:account, username: 'favourite') }
+
+      it 'returns an array of recent favourite tags ordered by order and id' do
+        specifieds = [
+          Fabricate(:favourite_tag, account: account, order: 9900),
+          Fabricate(:favourite_tag, account: account, order: 9800),
+          Fabricate(:favourite_tag, account: account, order: 9800),
+        ]
+        expect(account.favourite_tags.with_order.limit(3)).to match_array(specifieds)
+      end
+    end
+  end
+
   describe 'expect to_json_for_api' do
     let(:account) { Fabricate :account }
     let(:tag) { Tag.new(name: 'test_tag') }


### PR DESCRIPTION
お気に入りタグテーブルに表示順カラムを追加して
表示順をユーザーで変更できるように修正しました。
同時に、管理画面でお気に入りタグの編集機能を追加しました。

リリース前には
マイグレーション変更と既存DBの修正SQL実行をお願い致します。