### PR TITLE
announcementsクラスのmedia queryを削除

### DIFF
--- a/app/javascript/styles/imastodon/announcements.scss
+++ b/app/javascript/styles/imastodon/announcements.scss
@@ -44,9 +44,3 @@
     margin-top: 5px;
   }
 }
-
-@media screen and (max-width: 1024px) and (max-height: 400px) {
-  .announcements {
-    display: none;
-  }
-}


### PR DESCRIPTION
https://github.com/imas/mastodon/pull/144 でadmin_announcementsコンポーネントを削除したことにより、
https://github.com/imas/mastodon/issues/38 が根本的になくなったため