### PR TITLE
TrendTagSchedulerの実行後、トレンドタグのWebUIを自動更新するように変更

### DIFF
--- a/app/javascript/mastodon/actions/commands.js
+++ b/app/javascript/mastodon/actions/commands.js
@@ -1,5 +1,6 @@
 import { connectStream } from '../stream';
 import { UPDATE_ANNOUNCEMENTS } from './announcements';
+import { refreshTrendTags } from './trend_tags';
 
 export function connectCommandStream(pollingRefresh = null) {
   return connectStream('commands', pollingRefresh, (dispatch) => ({
@@ -12,6 +13,9 @@ export function connectCommandStream(pollingRefresh = null) {
           type: UPDATE_ANNOUNCEMENTS,
           data: JSON.parse(data.payload),
         });
+        break;
+      case 'trend_tags':
+        dispatch(refreshTrendTags());
         break;
       default:
         return;

--- a/app/javascript/mastodon/features/compose/components/trend_tags.js
+++ b/app/javascript/mastodon/features/compose/components/trend_tags.js
@@ -28,38 +28,6 @@ export default class TrendTags extends React.PureComponent {
   };
 
   componentDidMount() {
-    this.refresh();
-  }
-
-  componentWillUnmount() {
-    this.cancelPolling();
-  }
-
-  componentDidUpdate() {
-    this.setPolling();
-  }
-
-  setPolling = () => {
-    this.cancelPolling();
-    const now = new Date();
-    const min = now.getMinutes();
-    const sec = now.getSeconds();
-    let timeout = (610 - ((min + 5) % 10 * 60 + sec)) % 600 * 1000;
-    if (timeout === 0) {
-      timeout = 600 * 1000;
-    }
-    this.timer = setTimeout(this.refresh, timeout);
-  }
-
-  cancelPolling = () => {
-    if (this.timer !== null) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
-  }
-
-  refresh = () => {
-    this.cancelPolling();
     this.props.refreshTrendTags();
   }
 

--- a/app/workers/scheduler/trend_tag_scheduler.rb
+++ b/app/workers/scheduler/trend_tag_scheduler.rb
@@ -6,5 +6,6 @@ class Scheduler::TrendTagScheduler
 
   def perform
     StatusesTag.calc_trend
+    Redis.current.publish('commands', '{"event": "trend_tags"}')
   end
 end


### PR DESCRIPTION
TrendTagSchedulerの実行後、command streamを通じてトレンドタグのWebUIを自動更新するように変更しました。

通信不良などによりメッセージが届かなかった、または更新に失敗した時のために手動更新ボタンも残しています。