### PR TITLE
新規登録時に作成されるデフォルトのお気に入りタグを変更

### DIFF
--- a/app/lib/friends/favourite_tags_extension.rb
+++ b/app/lib/friends/favourite_tags_extension.rb
@@ -7,14 +7,16 @@ module Friends
       after_create :add_default_favourite_tag
 
       DEFAULT_TAGS = [
-        "みんなのP名刺",
-        "imas_img",
-        "ダイマストドン",
+        "デレラジ",
+        "デレパ",
+        "imasstation",
+        "millionradio",
+        "SideM",
       ].freeze
 
       def add_default_favourite_tag
         DEFAULT_TAGS.each_with_index do |tag_name, i|
-          self.favourite_tags.create!(visibility: 'public', tag: Tag.find_or_create_by!(name: tag_name), order: i)
+          self.favourite_tags.create!(visibility: 'unlisted', tag: Tag.find_or_create_by!(name: tag_name), order: (DEFAULT_TAGS.length - i))
         end
       end
 


### PR DESCRIPTION
https://github.com/imas/mastodon/pull/65 以降しばらく運用してみましたが、アイマス系ラジオのタグなどを直接的に登録しておかないとお気に入りタグ機能の意図が伝わらないなと思ったのでそのように変更します。

登録するタグはアイマストドン内でラジオの実況に使われてると思しきもの、順番は曜日順です。