### PR TITLE
use a sorted set to store the trend_tags

### DIFF
--- a/app/controllers/api/v1/trend_tags_controller.rb
+++ b/app/controllers/api/v1/trend_tags_controller.rb
@@ -5,8 +5,8 @@ class Api::V1::TrendTagsController < Api::BaseController
 
   def show
     trend_score = {
-      'updated_at' => redis.hget('trend_tag', 'updated_at'),
-      'score' => JSON.parse(redis.hget('trend_tag', 'score').presence || '{}'),
+      'updated_at' => redis.hget('trend_tags_management_data', 'updated_at'),
+      'score' => redis.zrevrange('trend_tags', 0, -1, withscores: true).to_h,
     }
     render json: trend_score
   end

--- a/app/workers/scheduler/trend_tags_update_scheduler.rb
+++ b/app/workers/scheduler/trend_tags_update_scheduler.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 require 'sidekiq-scheduler'
 
-class Scheduler::TrendTagScheduler
+class Scheduler::TrendTagsUpdateScheduler
   include Sidekiq::Worker
 
   def perform
-    StatusesTag.calc_trend
+    StatusesTag.update_trend_tags
     Redis.current.publish('commands', '{"event": "trend_tags"}')
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,9 +27,9 @@
   ip_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::IpCleanupScheduler
-  trend_tag_scheduler:
+  trend_tags_update_scheduler:
     cron: '5-55/10 * * * *'
-    class: Scheduler::TrendTagScheduler
+    class: Scheduler::TrendTagsUpdateScheduler
   email_scheduler:
     cron: '0 10 * * 2'
     class: Scheduler::EmailScheduler


### PR DESCRIPTION
Use a sorted set to store the trend_tags. `api/v1/trend_tags` returns the trend_tags in descending order of score.

Redisのソート済みセットを使ってトレンドタグを保存します。`api/v1/trend_tags`はトレンドタグをスコアの降順で返します。

値をソートする必要があるのはトレンドスコアのみなのでそれ以外はハッシュ型のままにしてあります。

またredisのキー名の変更やクラス名・メソッド名の変更も行います。
UI側でのソート操作の削除は別のPRでやります。