### PR TITLE
トレンドタグをお気に入りタグの上に移動

### DIFF
--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -98,8 +98,8 @@ export default class Compose extends React.PureComponent {
             <NavigationContainer onClose={this.onBlur} />
             <ComposeFormContainer />
             <AnnouncementsContainer />
-            <FavouriteTagsContainer />
             <TrendTagsContainer />
+            <FavouriteTagsContainer />
           </div>
 
           <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>


### PR DESCRIPTION
お知らせ、お気に入りタグ、トレンドタグのデフォルト状態がいずれも開いた状態のため、
お気に入りタグにたくさんのタグを登録していた場合、トレンドタグが画面外となってしまい見えません。
![image](https://user-images.githubusercontent.com/24884114/37532022-32a5129a-2981-11e8-90d0-160014b4f9ef.png)
