### PR TITLE
foldableコンポーネントをスクロール可能に変更

### DIFF
--- a/app/javascript/mastodon/components/foldable.js
+++ b/app/javascript/mastodon/components/foldable.js
@@ -6,7 +6,7 @@ import spring from 'react-motion/lib/spring';
 const Foldable = ({ fullHeight, minHeight, isVisible, children }) => (
   <Motion defaultStyle={{ height: isVisible ? fullHeight : minHeight }} style={{ height: spring(!isVisible ? minHeight : fullHeight) }}>
     {({ height }) =>
-      (<div style={{ height: `${height}px`, overflow: 'hidden' }}>
+      (<div style={{ height: `${height}px`, maxHeight: '20vh' }} class='scrollable optionally-scrollable'>
         {children}
       </div>)
     }


### PR DESCRIPTION
foldableコンポーネントのmax-heightを20vhに制限します。
これによりお気に入りタグをたくさん登録しているユーザでもトレンドタグがWebUIに収まるようになります。


|PC|スマホ|
|---|---|
|![image](https://user-images.githubusercontent.com/24884114/37781406-fba9c9e0-2e33-11e8-83f8-4d385428001c.png)|![image](https://user-images.githubusercontent.com/24884114/37781419-0746ae6c-2e34-11e8-93b0-0e69b026ff8d.png)|

related #157 
