### PR TITLE
allow only public or unlisted posts for trend_tags

### DIFF
--- a/app/models/statuses_tag.rb
+++ b/app/models/statuses_tag.rb
@@ -72,7 +72,7 @@ class StatusesTag < ApplicationRecord
     end
 
     def status_ids_in(time_range)
-      Status.where(created_at: time_range, local: true).map(&:id)
+      Status.where(created_at: time_range).local.with_public_or_unlisted_visibility.map(&:id)
     end
 
     def redis


### PR DESCRIPTION
im@stodonで誰宛でもないダイレクトにタグを乗せて投稿し続けると、他の誰にも見えないのにトレンドタグに載ってしまうという問題への対応です。**public**と**unlisted**のみを集計対象にします。

tagTLにも出ないprivateとdirectを集計対象に含めるのはむしろim@stodonのポリシーに反しているようにも思えますので最初からこうするべきでしたね。申し訳ないです。

あとlocal条件についてはStatusの方にscopeの定義があったのでそっちを使うようにしました。
