### PR TITLE
404画像を雪歩の画像に戻す

### DIFF
--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -99,3 +99,11 @@
     }
   }
 }
+
+.regeneration-indicator {
+  &.missing-indicator {
+    .regeneration-indicator__figure {
+      background-image: url('../images/mastodon-not-found.png');
+    }
+  }
+}


### PR DESCRIPTION
before

![notfound1](https://user-images.githubusercontent.com/11332152/38564492-34cb5f00-3d1a-11e8-89cc-e57d0b624619.jpg)


after

![notfound2](https://user-images.githubusercontent.com/11332152/38564513-3c68da6c-3d1a-11e8-945c-002a124c4833.jpg)

#6251 この修正で404画像が変わりましたので、CSSを修正して戻しました。
過不足ありましたら、お手数ですがご連絡ください。
