### PR TITLE
change position of im@stodon logo on getting-started

### DIFF
--- a/app/javascript/styles/imastodon/getting_started.scss
+++ b/app/javascript/styles/imastodon/getting_started.scss
@@ -1,8 +1,3 @@
-.getting-started__footer {
-  display: flex;
-  flex-direction: column;
-}
-
 .getting-started {
   box-sizing: border-box;
   padding-bottom: 235px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2210,7 +2210,7 @@ a.account__display-name {
   }
 
   &__footer {
-    flex: 0 0 auto;
+    flex: 1 0 auto;
     padding: 10px;
     padding-top: 20px;
 


### PR DESCRIPTION
Now
![mq14q2tixvwvzb51529553425_1529553483](https://user-images.githubusercontent.com/8458066/41701627-21aadac8-7568-11e8-8ce4-017156be11f7.png)

Changed
![default](https://user-images.githubusercontent.com/8458066/41701683-4b16e99c-7568-11e8-86f7-0e23ec4259b3.png)

and if the height is not enough
![1](https://user-images.githubusercontent.com/8458066/41701718-71e3c126-7568-11e8-879b-90c55faa92b0.png)

スタートカラムのアイマストドンのロゴ位置を変更します。ウィンドウ下部に追従します。高さが足りない時は従来通り下が切れる表示のままです。