### PR TITLE
ハイコントラストテーマとライトテーマが壊れていた問題を修正

### DIFF
--- a/app/javascript/styles/contrast.scss
+++ b/app/javascript/styles/contrast.scss
@@ -1,3 +1,5 @@
 @import 'contrast/variables';
 @import 'application';
 @import 'contrast/diff';
+@import 'theme_mastodon';
+

--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -86,7 +86,7 @@
 
   &__name {
     font-size: 14px;
-    color: $white;
+    color: $primary-text-color;
     text-decoration: none;
     width: 200px;
     overflow: hidden;

--- a/app/javascript/styles/imastodon/favourite_tags.scss
+++ b/app/javascript/styles/imastodon/favourite_tags.scss
@@ -18,7 +18,7 @@
   text-align: center;
 
   a {
-    color: $white;
+    color: $primary-text-color;
   }
 }
 

--- a/app/javascript/styles/mastodon-light.scss
+++ b/app/javascript/styles/mastodon-light.scss
@@ -1,3 +1,5 @@
 @import 'mastodon-light/variables';
 @import 'application';
 @import 'mastodon-light/diff';
+@import 'theme_mastodon';
+


### PR DESCRIPTION
- お気に入りタグ周りでwhiteベタ書きしていた部分をprimary-text-colorに修正

ハイコントラストテーマの公開範囲アイコンが背景と同化してしまっていますが、これは今小手先で直すというよりもscssのアイマストドン独自部分全体のリファクタリング案件だと思うので別途対応します。

## ハイコントラストテーマ
![image](https://user-images.githubusercontent.com/24884114/41939778-bd94b5cc-79d1-11e8-962f-d8f49b0378fd.png)

## ライトテーマ
![image](https://user-images.githubusercontent.com/24884114/41939834-e17b93d4-79d1-11e8-9f36-f96d361f23d3.png)
