### PR TITLE
Show TrendTag history graph

### DIFF
--- a/app/controllers/api/v1/trend_tags_controller.rb
+++ b/app/controllers/api/v1/trend_tags_controller.rb
@@ -4,14 +4,29 @@ class Api::V1::TrendTagsController < Api::BaseController
   respond_to :json
 
   def show
-    trend_score = {
-      'updated_at' => redis.hget('trend_tags_management_data', 'updated_at'),
-      'score' => redis.zrevrange('trend_tags', 0, -1, withscores: true).to_h,
-    }
     render json: trend_score
   end
 
   private
+
+  def trend_score
+    if history_mode?
+      redis.lrange('trend_tags_history', 0, -1).map { |item| JSON.parse(item) }
+    else
+      {
+        'updated_at' => redis.hget('trend_tags_management_data', 'updated_at'),
+        'score' => redis.zrevrange('trend_tags', 0, -1, withscores: true).to_h,
+      }
+    end
+  end
+
+  def history_mode?
+    ActiveModel::Type::Boolean.new.cast(trend_tags_params[:history_mode]) 
+  end
+
+  def trend_tags_params
+    params.permit(:history_mode)
+  end
 
   def redis
     Redis.current

--- a/app/javascript/mastodon/actions/trend_tags.js
+++ b/app/javascript/mastodon/actions/trend_tags.js
@@ -1,6 +1,7 @@
 import api from '../api';
 
 export const TREND_TAGS_SUCCESS = 'TREND_TAGS_SUCCESS';
+export const TREND_TAGS_HISTORY_SUCCESS = 'TREND_TAGS_HISTORY_SUCCESS';
 export const TOGGLE_TREND_TAGS = 'TOGGLE_TREND_TAGS';
 
 export function refreshTrendTags() {
@@ -21,5 +22,20 @@ export function refreshTrendTagsSuccess(tags) {
 export function toggleTrendTags() {
   return {
     type: TOGGLE_TREND_TAGS,
+  };
+}
+
+export function refreshTrendTagsHistory() {
+  return (dispatch, getState) => {
+    api(getState).get('/api/v1/trend_tags?history_mode=true').then(response => {
+      dispatch(refreshTrendTagsHistorySuccess(response.data));
+    });
+  };
+}
+
+export function refreshTrendTagsHistorySuccess(tags) {
+  return {
+    type: TREND_TAGS_HISTORY_SUCCESS,
+    tags,
   };
 }

--- a/app/javascript/mastodon/features/compose/containers/trend_tags_container.js
+++ b/app/javascript/mastodon/features/compose/containers/trend_tags_container.js
@@ -1,10 +1,14 @@
 import { connect } from 'react-redux';
 import TrendTags from '../components/trend_tags';
-import { refreshTrendTags, toggleTrendTags } from '../../../actions/trend_tags';
+import { refreshTrendTags,
+  refreshTrendTagsHistory,
+  toggleTrendTags,
+} from '../../../actions/trend_tags';
 
 const mapStateToProps = state => {
   return {
     trendTags: state.getIn(['trend_tags', 'tags', 'score']),
+    trendTagsHistory: state.getIn(['trend_tags', 'history']),
     visible: state.getIn(['trend_tags', 'visible']),
     favouriteTags: state.getIn(['favourite_tags', 'tags']),
   };
@@ -13,6 +17,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   refreshTrendTags () {
     dispatch(refreshTrendTags());
+    dispatch(refreshTrendTagsHistory());
   },
   onToggle () {
     dispatch(toggleTrendTags());

--- a/app/javascript/mastodon/reducers/trend_tags.js
+++ b/app/javascript/mastodon/reducers/trend_tags.js
@@ -1,4 +1,7 @@
-import { TREND_TAGS_SUCCESS, TOGGLE_TREND_TAGS } from '../actions/trend_tags';
+import { TREND_TAGS_SUCCESS,
+  TREND_TAGS_HISTORY_SUCCESS,
+  TOGGLE_TREND_TAGS
+} from '../actions/trend_tags';
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
@@ -6,6 +9,7 @@ const initialState = Immutable.Map({
     updated_at: '',
     score: Immutable.Map(),
   }),
+  history: Immutable.List(),
   visible: true,
 });
 
@@ -13,6 +17,8 @@ export default function trend_tags(state = initialState, action) {
   switch(action.type) {
   case TREND_TAGS_SUCCESS:
     return state.set('tags', Immutable.fromJS(action.tags));
+  case TREND_TAGS_HISTORY_SUCCESS:
+    return state.set('history', Immutable.fromJS(action.tags));
   case TOGGLE_TREND_TAGS:
     return state.set('visible', !state.get('visible'));
   default:

--- a/app/javascript/styles/imastodon/compose_common.scss
+++ b/app/javascript/styles/imastodon/compose_common.scss
@@ -61,9 +61,10 @@
     counter-reset: index;
 
     li {
+      height: 30px;
       display: flex;
       align-items: center;
-      padding: 6px 10px;
+      padding: 0px 10px;
       position: relative;
 
       &:before {

--- a/app/javascript/styles/imastodon/trend_tags.scss
+++ b/app/javascript/styles/imastodon/trend_tags.scss
@@ -3,16 +3,32 @@
   * features/compose/components/trend_tags
   */
 
-.trend-tags__fav {
-  color: $ui-base-lighter-color;
-  position: absolute;
-  top: 50%;
-  right: 20px;
-  margin-top: -7px;
-  width: 14px;
-  text-align: center;
+.trend-tags__sparkline {
+  &.normal {
+    flex: 0 0 auto;
+    width: 50px;
 
-  &.active {
-    color: $gold-star;
+    path:first-child {
+      fill: lighten($highlight-text-color, 6%) !important;
+      fill-opacity: 0.3 !important;
+    }
+
+    path:nth-child(2) {
+      stroke: lighten($highlight-text-color, 6%) !important;
+    }
+  }
+
+  &.fever {
+    flex: 0 0 auto;
+    width: 50px;
+
+    path:first-child {
+      fill: lighten($error-value-color, 6%) !important;
+      fill-opacity: 0.3 !important;
+    }
+
+    path:nth-child(2) {
+      stroke: lighten($error-value-color, 6%) !important;
+    }
   }
 }


### PR DESCRIPTION
タグの盛り上がりをより分かりやすく可視化するために、トレンドタグUIにトレンドスコアをもとにしたグラフを表示します。また、従来表示されていたお気に入りマークは削除します。
![3](https://user-images.githubusercontent.com/8458066/42123502-265759e8-7c8e-11e8-8596-817c5e35e675.png)

過去12集計(2時間)のスコアと現在のスコアを合わせた13点をデータとして使いグラフを描画します。
現在のスコアが20以上である場合はグラフを赤くします。
グラフの縦方向のスケールは、その時にトレンドタグとして登場する全タグのデータから、最大値をMaxとします。

過去12集計のデータはRedisに保存します。
apiでは、api/v1/trend_tags の history_mode パラメータにtrueになりそうな感じの (0とかfalseとか以外の) 値が渡されたときに過去のデータを返すようにします。そうでない場合は現在のデータを返します。