### PR TITLE
スタートカラムのアイマストドンのロゴ位置修正

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -83,6 +83,7 @@ export default class GettingStarted extends ImmutablePureComponent {
     const { intl, myAccount, multiColumn, github_url, github_name, unreadFollowRequests } = this.props;
 
     const navItems = [];
+    const devItems = [];
     let i = 1;
     let height = (multiColumn) ? 0 : 60;
 
@@ -124,6 +125,41 @@ export default class GettingStarted extends ImmutablePureComponent {
       height += 34 + 48;
     }
 
+    devItems.push(
+      <div key={i++} className='getting-started__wrapper' style={{ height }}>
+        {!multiColumn && <NavigationBar account={myAccount} />}
+        {navItems}
+      </div>
+    );
+    if (!multiColumn) {
+      devItems.push(
+        <div key={i++} className='flex-spacer' />
+      );
+    }
+    devItems.push(
+      <div key={i++} className='getting-started getting-started__footer'>
+        <ul>
+          <li><a href='https://bridge.joinmastodon.org/' target='_blank'><FormattedMessage id='getting_started.find_friends' defaultMessage='Find friends from Twitter' /></a> · </li>
+          {invitesEnabled && <li><a href='/invites' target='_blank'><FormattedMessage id='getting_started.invite' defaultMessage='Invite people' /></a> · </li>}
+          {multiColumn && <li><Link to='/keyboard-shortcuts'><FormattedMessage id='navigation_bar.keyboard_shortcuts' defaultMessage='Hotkeys' /></Link> · </li>}
+          <li><a href='/auth/edit'><FormattedMessage id='getting_started.security' defaultMessage='Security' /></a> · </li>
+          <li><a href='/about/more' target='_blank'><FormattedMessage id='navigation_bar.info' defaultMessage='About this instance' /></a> · </li>
+          <li><a href='/terms' target='_blank'><FormattedMessage id='getting_started.terms' defaultMessage='Terms of service' /></a> · </li>
+          <li><a href='/settings/applications' target='_blank'><FormattedMessage id='getting_started.developers' defaultMessage='Developers' /></a> · </li>
+          <li><a href='https://github.com/tootsuite/documentation#documentation' target='_blank'><FormattedMessage id='getting_started.documentation' defaultMessage='Documentation' /></a> · </li>
+          <li><a href='/auth/sign_out' data-method='delete'><FormattedMessage id='navigation_bar.logout' defaultMessage='Logout' /></a></li>
+        </ul>
+
+        <p>
+          <FormattedMessage
+            id='getting_started.open_source_notice'
+            defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
+            values={{ github: <a href={github_url} rel='noopener' target='_blank'>{github_name}</a> }}
+          />
+        </p>
+      </div>
+    );
+
     return (
       <Column>
         {multiColumn && <div className='column-header__wrapper'>
@@ -135,34 +171,8 @@ export default class GettingStarted extends ImmutablePureComponent {
           </h1>
         </div>}
 
-        <div className='getting-started__wrapper' style={{ height }}>
-          {!multiColumn && <NavigationBar account={myAccount} />}
-          {navItems}
-        </div>
+        {!multiColumn ? <div className='scrollable optionally-scrollable'>{devItems}</div> : devItems}
 
-        {!multiColumn && <div className='flex-spacer' />}
-
-        <div className='getting-started getting-started__footer'>
-          <ul>
-            <li><a href='https://bridge.joinmastodon.org/' target='_blank'><FormattedMessage id='getting_started.find_friends' defaultMessage='Find friends from Twitter' /></a> · </li>
-            {invitesEnabled && <li><a href='/invites' target='_blank'><FormattedMessage id='getting_started.invite' defaultMessage='Invite people' /></a> · </li>}
-            {multiColumn && <li><Link to='/keyboard-shortcuts'><FormattedMessage id='navigation_bar.keyboard_shortcuts' defaultMessage='Hotkeys' /></Link> · </li>}
-            <li><a href='/auth/edit'><FormattedMessage id='getting_started.security' defaultMessage='Security' /></a> · </li>
-            <li><a href='/about/more' target='_blank'><FormattedMessage id='navigation_bar.info' defaultMessage='About this instance' /></a> · </li>
-            <li><a href='/terms' target='_blank'><FormattedMessage id='getting_started.terms' defaultMessage='Terms of service' /></a> · </li>
-            <li><a href='/settings/applications' target='_blank'><FormattedMessage id='getting_started.developers' defaultMessage='Developers' /></a> · </li>
-            <li><a href='https://github.com/tootsuite/documentation#documentation' target='_blank'><FormattedMessage id='getting_started.documentation' defaultMessage='Documentation' /></a> · </li>
-            <li><a href='/auth/sign_out' data-method='delete'><FormattedMessage id='navigation_bar.logout' defaultMessage='Logout' /></a></li>
-          </ul>
-
-          <p>
-            <FormattedMessage
-              id='getting_started.open_source_notice'
-              defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
-              values={{ github: <a href={github_url} rel='noopener' target='_blank'>{github_name}</a> }}
-            />
-          </p>
-        </div>
       </Column>
     );
   }

--- a/app/javascript/styles/imastodon/getting_started.scss
+++ b/app/javascript/styles/imastodon/getting_started.scss
@@ -1,13 +1,12 @@
-.getting-started__footer {
-  display: flex;
-  flex-direction: column;
-}
-
 .getting-started {
   box-sizing: border-box;
   padding-bottom: 235px;
   background: url('../images/mastodon-ui.png') no-repeat 0 100%;
   background-size: contain;
+
+  &__footer {
+    flex: 1 0 auto;
+  }
 }
 
 .column-link {


### PR DESCRIPTION
#121 の時の修正のように、scrollable のdivを入れてPC/SPで
見やすくなるように修正致しました。

PC
![03](https://user-images.githubusercontent.com/11332152/44529435-0f79be00-a727-11e8-8a44-08c73c1a6f76.jpg)

SP
![02](https://user-images.githubusercontent.com/11332152/44529448-186a8f80-a727-11e8-93c6-a44e7559de98.jpg)


resolves #174