### PR TITLE
fix filters language on im@s

### DIFF
--- a/config/locales/ja-IM.yml
+++ b/config/locales/ja-IM.yml
@@ -512,9 +512,9 @@ ja-IM:
     submit: お気に入りタグを登録
   filters:
     contexts:
-      home: 楽屋
-      notifications: 通知
-      public: ライブステージ
+      home: オフィス
+      notifications: ホワイトボード
+      public: 楽屋
       thread: 会話
     edit:
       title: フィルターを編集


### PR DESCRIPTION
fixes #185 

公開タイムラインという言葉がここでしか出てこない(おそらく)初出となる
文言になると思いますので、im@s語で該当する言葉はありません。
ですが、公開されているタイムライン = 入り口からでも見える ≒ ローカルタイムライン
という解釈でひとまず「楽屋」とさせて頂きました。

問題ありそう、もしくは他によさそうな言葉がありましたらご指摘ください。

![02](https://user-images.githubusercontent.com/11332152/44626777-a334cf80-a95d-11e8-8803-3d6a77c75f94.jpg)

