### PR TITLE
getting-startedコンポーネントの下端にアイマストドンロゴが追従していなかった問題を修正

### DIFF
--- a/app/javascript/styles/imastodon/getting_started.scss
+++ b/app/javascript/styles/imastodon/getting_started.scss
@@ -1,13 +1,12 @@
-.getting-started__footer {
-  display: flex;
-  flex-direction: column;
-}
-
 .getting-started {
   box-sizing: border-box;
-  padding-bottom: 235px;
   background: url('../images/mastodon-ui.png') no-repeat 0 100%;
   background-size: contain;
+  height: 100%;
+
+  .getting-started__footer{ 
+    background-color: rgba($ui-base-color, 0.9);
+  }
 }
 
 .column-link {


### PR DESCRIPTION
getting-started__wrapperクラスがgetting-startedに包まれていなかったあたりとか、
なんか微妙に本家案件な気もします（したぶんそこはリファクタリングとして本家にPR出します）が、
それはそれとしてこれで下端に追従しない問題は解消されているはず。

|PC|縦長1|縦長2|
|:--:|:--:|:--:|
|![image](https://user-images.githubusercontent.com/24884114/44884140-20ad6680-acf5-11e8-88ad-7691177cb784.png)|![image](https://user-images.githubusercontent.com/24884114/44884122-0d020000-acf5-11e8-807b-919f29df4292.png)|![image](https://user-images.githubusercontent.com/24884114/44884112-fe1b4d80-acf4-11e8-9771-5896bb4ff996.png)|

