### PR TITLE
WebSocketのstreamingが一部条件において新しいメッセージを正しく配送していなかった問題を修正

### DIFF
--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -47,6 +47,6 @@ const refreshHomeTimelineAndNotification = (dispatch, done) => {
 export const connectUserStream      = () => connectTimelineStream('home', 'user', refreshHomeTimelineAndNotification);
 export const connectCommunityStream = ({ onlyMedia } = {}) => connectTimelineStream(`community${onlyMedia ? ':media' : ''}`, `public:local${onlyMedia ? ':media' : ''}`);
 export const connectPublicStream    = ({ onlyMedia } = {}) => connectTimelineStream(`public${onlyMedia ? ':media' : ''}`, `public${onlyMedia ? ':media' : ''}`);
-export const connectHashtagStream   = (tag, isLocal) => connectTimelineStream(`hashtag:${tag}`, `hashtag&tag=${tag}${ isLocal ? ':local' : '' }`);
+export const connectHashtagStream   = (tag, isLocal) => connectTimelineStream(`hashtag:${tag}`, `hashtag${ isLocal ? ':local' : '' }&tag=${tag}`);
 export const connectDirectStream    = () => connectTimelineStream('direct', 'direct');
 export const connectListStream      = id => connectTimelineStream(`list:${id}`, `list&list=${id}`);


### PR DESCRIPTION
`app/javascript/mastodon/actions/streaming.js` においてconnectHashtagStreamアクションのisLocalがtrueであった場合に`:local`が差し込まれる個所が間違っていたため、正しく動作していませんでした。

![image](https://user-images.githubusercontent.com/24884114/45629179-c243fe80-bad0-11e8-810d-daa611b0dccd.png)


close #193