### PR TITLE
Mastodon(ライト)テーマのカラーリング修正

### DIFF
--- a/app/javascript/styles/mastodon-light.scss
+++ b/app/javascript/styles/mastodon-light.scss
@@ -2,4 +2,5 @@
 @import 'application';
 @import 'mastodon-light/diff';
 @import 'theme_mastodon';
+@import 'mastodon-light/imastodon';
 

--- a/app/javascript/styles/mastodon-light/imastodon.scss
+++ b/app/javascript/styles/mastodon-light/imastodon.scss
@@ -1,0 +1,12 @@
+.announcements {
+  li {
+    color: $black;
+  }
+}
+
+.announcements__body {
+  a {
+    color: $black;
+    border: solid 1px $ui-base-lighter-color;
+  }
+}

--- a/app/javascript/styles/mastodon-light/variables.scss
+++ b/app/javascript/styles/mastodon-light/variables.scss
@@ -16,7 +16,7 @@ $valid-value-color: $success-green !default;
 $ui-base-color: $classic-secondary-color !default;
 $ui-base-lighter-color: #b0c0cf;
 $ui-primary-color: #9bcbed;
-$ui-secondary-color: $classic-base-color !default;
+$ui-secondary-color: #999999;
 $ui-highlight-color: #2b5fd9;
 
 $primary-text-color: $black !default;


### PR DESCRIPTION
Fixed #172

* お知らせの文字色修正

* ui-secondary-color(ドロップダウンメニュー等)の背景色修正

![02](https://user-images.githubusercontent.com/11332152/47223219-ab583b00-d3f3-11e8-92cb-d7fddbb035f1.jpg)
