### PR TITLE
トレンドタグのupdated_atにActiveModel::Serializers::JSON.as_jsonを利用する

### DIFF
--- a/app/models/statuses_tag.rb
+++ b/app/models/statuses_tag.rb
@@ -20,7 +20,7 @@ class StatusesTag < ApplicationRecord
 
     def get_data
       unless redis.exists('trend_tags_management_data')
-        redis.hset('trend_tags_management_data', 'updated_at', Time.now.utc.iso8601)
+        redis.hset('trend_tags_management_data', 'updated_at', Time.now.utc.as_json)
       end
       [
         aggregate_tags_in,

--- a/app/models/statuses_tag.rb
+++ b/app/models/statuses_tag.rb
@@ -44,7 +44,7 @@ class StatusesTag < ApplicationRecord
         r.lpush('trend_tags_history', previous_score.to_json)
         r.del('trend_tags')
         r.zadd('trend_tags', score) unless score.empty?
-        r.hmset('trend_tags_management_data', 'updated_at', Time.now.utc.iso8601, 'level_L', level.to_json, 'trend_L', trend.to_json)
+        r.hmset('trend_tags_management_data', 'updated_at', Time.now.utc.as_json, 'level_L', level.to_json, 'trend_L', trend.to_json)
       end
     end
 


### PR DESCRIPTION
他のAPIとの表記の互換性を取るため