### PR TITLE
時間がかかるマイグレーションをrakeタスクに切り出し

### DIFF
--- a/db/migrate/20181024224956_migrate_account_conversations.rb
+++ b/db/migrate/20181024224956_migrate_account_conversations.rb
@@ -2,40 +2,7 @@ class MigrateAccountConversations < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up
-    say ''
-    say 'WARNING: This migration may take a *long* time for large instances'
-    say 'It will *not* lock tables for any significant time, but it may run'
-    say 'for a very long time. We will pause for 10 seconds to allow you to'
-    say 'interrupt this migration if you are not ready.'
-    say ''
-
-    10.downto(1) do |i|
-      say "Continuing in #{i} second#{i == 1 ? '' : 's'}...", true
-      sleep 1
-    end
-
-    migrated  = 0
-    last_time = Time.zone.now
-
-    local_direct_statuses.includes(:account, mentions: :account).find_each do |status|
-      AccountConversation.add_status(status.account, status)
-      migrated += 1
-
-      if Time.zone.now - last_time > 1
-        say_progress(migrated)
-        last_time = Time.zone.now
-      end
-    end
-
-    notifications_about_direct_statuses.includes(:account, mention: { status: [:account, mentions: :account] }).find_each do |notification|
-      AccountConversation.add_status(notification.account, notification.target_status)
-      migrated += 1
-
-      if Time.zone.now - last_time > 1
-        say_progress(migrated)
-        last_time = Time.zone.now
-      end
-    end
+    # migrated to rake task
   end
 
   def down

--- a/db/migrate/20181227000032_add_index_statuses_on_visibility.rb
+++ b/db/migrate/20181227000032_add_index_statuses_on_visibility.rb
@@ -1,0 +1,7 @@
+class AddIndexStatusesOnVisibility < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  def change
+    add_index :notifications, [:activity_type, :id], algorithm: :concurrently
+    add_index :statuses, [:visibility, :id], algorithm: :concurrently, where: "(local = TRUE OR uri IS NULL)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_26_034033) do
+ActiveRecord::Schema.define(version: 2018_12_27_000032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -354,6 +354,7 @@ ActiveRecord::Schema.define(version: 2018_10_26_034033) do
     t.index ["account_id", "activity_id", "activity_type"], name: "account_activity", unique: true
     t.index ["account_id", "id"], name: "index_notifications_on_account_id_and_id", order: { id: :desc }
     t.index ["activity_id", "activity_type"], name: "index_notifications_on_activity_id_and_activity_type"
+    t.index ["activity_type", "id"], name: "index_notifications_on_activity_type_and_id"
     t.index ["from_account_id"], name: "index_notifications_on_from_account_id"
   end
 
@@ -548,6 +549,7 @@ ActiveRecord::Schema.define(version: 2018_10_26_034033) do
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"
     t.index ["uri"], name: "index_statuses_on_uri", unique: true
+    t.index ["visibility", "id"], name: "index_statuses_on_visibility_and_id", where: "((local = true) OR (uri IS NULL))"
   end
 
   create_table "statuses_tags", id: false, force: :cascade do |t|

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -4,6 +4,27 @@ require 'tty-command'
 require 'tty-prompt'
 
 namespace :mastodon do
+  namespace :migrate do
+    desc 'migrate AccountConversation'
+    task accountConversation: :environment do
+      migrated  = 0
+      Status.unscoped.local.where(visibility: :direct).includes(:account, mentions: :account).find_each do |status|
+        AccountConversation.add_status(status.account, status)
+        migrated += 1
+  
+        puts "Migrated #{migrated} rows"
+      end
+  
+      puts
+      Notification.joins(mention: :status).where(activity_type: 'Mention', statuses: { visibility: :direct }).includes(:account, mention: { status: [:account, mentions: :account] }).find_each do |notification|
+        AccountConversation.add_status(notification.account, notification.target_status)
+        migrated += 1
+  
+        puts "Migrated #{migrated} rows"
+      end  
+    end
+  end
+
   desc 'Configure the instance for production use'
   task :setup do
     prompt = TTY::Prompt.new


### PR DESCRIPTION
v2.6.5アップデートに伴うdb:migrateのうち、20181024224956_migrate_account_conversations がむちゃくちゃ時間かかるので、rakeタスクに切り出します。

これを実行するまで、ダイレクトメッセージカラムにメッセージが表示されません。
※ホームTLカラムや、通知カラムには表示されます