### PR TITLE
「フィルターされました」表示を非表示に変更

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -196,18 +196,7 @@ class Status extends ImmutablePureComponent {
     }
 
     if (status.get('filtered') || status.getIn(['reblog', 'filtered'])) {
-      const minHandlers = this.props.muted ? {} : {
-        moveUp: this.handleHotkeyMoveUp,
-        moveDown: this.handleHotkeyMoveDown,
-      };
-
-      return (
-        <HotKeys handlers={minHandlers}>
-          <div className='status__wrapper status__wrapper--filtered focusable' tabIndex='0'>
-            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />
-          </div>
-        </HotKeys>
-      );
+      return null;
     }
 
     if (featured) {


### PR DESCRIPTION
fixes #187

|before|after|  
----|---- 
|![02](https://user-images.githubusercontent.com/11332152/50586014-0cec5980-0ebb-11e9-87c9-4ba11da24e36.jpg)|![03](https://user-images.githubusercontent.com/11332152/50586205-de22b300-0ebb-11e9-82d1-e76ea1444d5d.jpg)|  

少し迷ったのですが、このPRでは無条件で非表示にしています。
本家でも議論されているように、accountに表示するかどうかのフラグを設けるとか、
色々あると思いますが、私個人ではこのフィルターの表示は必要ないと思っています。

アイマストドンくらいの大規模インスタンスだと、
この修正で不具合が起こる可能性も考えられますので、
お手数ですがご確認をお願いしたく、よろしくお願い致します。
