### PR TITLE
Revert "cancel sorting trend tags in the UI side"

### DIFF
--- a/app/javascript/mastodon/reducers/trend_tags.js
+++ b/app/javascript/mastodon/reducers/trend_tags.js
@@ -16,7 +16,10 @@ const initialState = Immutable.Map({
 export default function trend_tags(state = initialState, action) {
   switch(action.type) {
   case TREND_TAGS_SUCCESS:
-    return state.set('tags', Immutable.fromJS(action.tags));
+    const tmp = Immutable.fromJS(action.tags);
+    return state.set('tags', tmp.set('score', tmp.get('score').sort((a, b) => {
+      return b - a;
+    })));
   case TREND_TAGS_HISTORY_SUCCESS:
     return state.set('history', Immutable.fromJS(action.tags));
   case TOGGLE_TREND_TAGS:


### PR DESCRIPTION
fix #165 
This reverts commit d72abcf351161b068496b38675fda1306d21de74.

やはりImmutable.jsのMapでは順序が保証されないのが原因みたいなのでUI側でソートかけることにします。
