### PR TITLE
fix avatar and display name on direct conversation

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -277,7 +277,7 @@ class Status extends ImmutablePureComponent {
       );
     }
 
-    if (account === undefined || account === null) {
+    if (account == null) {
       if (status.get('visibility') === 'public') {
         statusAvatar = <Avatar account={status.get('account')} size={48} />;
       } else {

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -277,9 +277,7 @@ class Status extends ImmutablePureComponent {
       );
     }
 
-    if (otherAccounts) {
-      statusAvatar = <AvatarComposite accounts={otherAccounts} size={48} />;
-    } else if (account === undefined || account === null) {
+    if (account === undefined || account === null) {
       if (status.get('visibility') === 'public') {
         statusAvatar = <Avatar account={status.get('account')} size={48} />;
       } else {


### PR DESCRIPTION
fix #217 

tootsuite/mastodon#9190
tootsuite/mastodon#10047 
なお、上記2つによって「DMカラムは会話の最後が誰であっても相手のアバターと名前を表示する」仕様になったらしいので、これをどうするかは要検討でしょうか。
TwitterのDM一覧画面も常に相手のアイコンだからということでこの仕様になったみたいですが、MastodonではDMは他のカラムと同じインタフェースなので齟齬が生じているように見えますよね。