### PR TITLE
開発用docker-composeファイルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ About what is Mastodon, see [tootsuite/mastodon](https://github.com/tootsuite/ma
 - 未収載タグ付き投稿のタグTLへの表示
 - お気に入りタグ機能
 
+## 開発用docker-composeファイル
+開発に必要なpostgresqlとredisはdocker-composeを用いて1コマンドで起動できるようになっています。
+```
+docker-compose -f docker-compose-dev.yml up -d
+```
+
+また、docker-composeで起動したそれらに接続するために下記の内容を`.env`という名前のファイルとして保存してください。
+```
+DB_HOST=localhost
+DB_USER=mastodon
+DB_PASS=mastodon
+```
+
 ![Mastodon](https://i.imgur.com/NhZc40l.png)
 ========
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  db:
+    image: postgres:9.5-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - "POSTGRES_USER=mastodon"
+      - "POSTGRES_PASSWORD=mastodon"
+  redis:
+    image: redis:3.2.4-alpine
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
開発環境を新調した関係でaptから入るpostgresqlとredisのバージョンが異なってしまう問題が生じたのでdocker-composeを使って起動するようにしました。
ついでにリポジトリに含めておくことで開発環境の構築を楽にすることも企図しています。