### PR TITLE
Fix/reduce redundant methods of media attachment

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -137,7 +137,7 @@ class MediaAttachment < ApplicationRecord
   before_create :prepare_description, unless: :local?
   before_create :set_shortcode
   before_post_process :set_type_and_extension
-  after_post_process :set_extension
+  after_post_process :set_file_extensions
   before_save :set_meta
 
   class << self
@@ -165,7 +165,7 @@ class MediaAttachment < ApplicationRecord
       if f.file_content_type == 'image/gif'
         [:gif_transcoder]
       elsif f.file_content_type == 'image/png'
-        [:img_converter, :thumbnail]
+        [:png_converter, :thumbnail]
       elsif VIDEO_MIME_TYPES.include? f.file_content_type
         [:video_transcoder]
       else
@@ -193,12 +193,6 @@ class MediaAttachment < ApplicationRecord
 
   def set_type_and_extension
     self.type = VIDEO_MIME_TYPES.include?(file_content_type) ? :video : :image
-  end
-
-  def set_extension
-    extension = appropriate_extension(file)
-    basename  = Paperclip::Interpolations.basename(file, :original)
-    file.instance_write :file_name, [basename, extension].delete_if(&:blank?).join('.')
   end
 
   def set_meta

--- a/lib/paperclip/png_converter.rb
+++ b/lib/paperclip/png_converter.rb
@@ -3,7 +3,7 @@
 module Paperclip
   # This transcoder is only to be used for the MediaAttachment model
   # to convert images to JPG (except for transparent PNG)
-  class ImgConverter < Processor
+  class PngConverter < Processor
     def make
       opaque = identify('-format "%[opaque]" :src', src: File.expand_path(file.path)).strip.downcase
 

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -129,8 +129,9 @@ RSpec.describe MediaAttachment, type: :model do
       expect(media.type).to eq 'image'
     end
 
-    it 'leaves original file as-is' do
+    it 'file_content_typeと拡張子がjpegに設定されている' do
       expect(media.file_content_type).to eq 'image/jpeg'
+      expect(media.file_file_name).to end_with 'jpeg'
     end
 
     it 'sets meta' do
@@ -147,8 +148,9 @@ RSpec.describe MediaAttachment, type: :model do
       expect(media.type).to eq 'image'
     end
 
-    it 'leaves original file as-is' do
+    it 'file_content_typeと拡張子がpngのまま' do
       expect(media.file_content_type).to eq 'image/png'
+      expect(media.file_file_name).to end_with 'png'
     end
 
     it 'sets meta' do
@@ -165,8 +167,9 @@ RSpec.describe MediaAttachment, type: :model do
       expect(media.type).to eq 'image'
     end
 
-    it 'leaves original file as-is' do
+    it 'file_content_typeと拡張子がpngのまま' do
       expect(media.file_content_type).to eq 'image/png'
+      expect(media.file_file_name).to end_with 'png'
     end
 
     it 'sets meta' do


### PR DESCRIPTION
MediaAttachmentクラスのテストに拡張子に関する項を追加し、MediaAttachmentクラスの冗長なメソッド定義を削除します。

- set_extensionメソッドと同内容の処理がAttachmentableモジュールにあったのでそちらを使うように
- ImgConverterクラスをPngConverterクラスにリネーム
  - png形式の画像にのみ適用している現状をより正しく表すため