### PR TITLE
update ハッシュタグタイムラインのタグ登録/解除ボタンを復活

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/components/favourite_toggle.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/favourite_toggle.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '../../../components/button';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+const messages = defineMessages({
+  add_favourite_tags_public: { id: 'tag.add_favourite.public', defaultMessage: 'add in the favourite tags (Public)' },
+  add_favourite_tags_unlisted: { id: 'tag.add_favourite.unlisted', defaultMessage: 'add in the favourite tags (Unlisted)' },
+  remove_favourite_tags: { id: 'tag.remove_favourite', defaultMessage: 'Remove from the favourite tags' },
+});
+
+@injectIntl
+export default class FavouriteToggle extends React.PureComponent {
+
+  static propTypes = {
+    tag: PropTypes.string.isRequired,
+    addFavouriteTags: PropTypes.func.isRequired,
+    removeFavouriteTags: PropTypes.func.isRequired,
+    isRegistered: PropTypes.bool.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  addFavouriteTags = (visibility) => {
+    this.props.addFavouriteTags(this.props.tag, visibility);
+  };
+
+  addPublic = () => {
+    this.addFavouriteTags('public');
+  };
+
+  addUnlisted = () => {
+    this.addFavouriteTags('unlisted');
+  };
+
+  removeFavouriteTags = () => {
+    this.props.removeFavouriteTags(this.props.tag);
+  };
+
+  render () {
+    const { intl, isRegistered } = this.props;
+
+    return (
+      <div>
+        { isRegistered ?
+          <div className='column-settings__row'>
+            <Button className='favourite-tags__remove-button-in-column' text={intl.formatMessage(messages.remove_favourite_tags)} onClick={this.removeFavouriteTags} block />
+          </div>
+        :
+          <div className='column-settings__row'>
+            <Button className='favourite-tags__add-button-in-column' text={intl.formatMessage(messages.add_favourite_tags_public)} onClick={this.addPublic} block />
+            <Button className='favourite-tags__add-button-in-column' text={intl.formatMessage(messages.add_favourite_tags_unlisted)} onClick={this.addUnlisted} block />
+          </div>
+        }
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/hashtag_timeline/containers/favourite_toggle_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/favourite_toggle_container.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import FavouriteToggle from '../components/favourite_toggle';
+import { addFavouriteTags, removeFavouriteTags } from '../../../actions/favourite_tags';
+
+const mapStateToProps = (state, { tag }) => ({
+  isRegistered: state.getIn(['favourite_tags', 'tags']).some(t => t.get('name') === tag),
+});
+
+const mapDispatchToProps = dispatch => ({
+
+  addFavouriteTags (tag, visibility) {
+    dispatch(addFavouriteTags(tag, visibility));
+  },
+
+  removeFavouriteTags (tag) {
+    dispatch(removeFavouriteTags(tag));
+  },
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(FavouriteToggle);

--- a/app/javascript/mastodon/features/hashtag_timeline/index.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.js
@@ -6,6 +6,7 @@ import Column from '../../components/column';
 import ColumnHeader from '../../components/column_header';
 import ColumnSettingsContainer from './containers/column_settings_container';
 import ShowLocalSettingsContainer from './containers/show_local_settings_container';
+import FavouriteToggleContainer from './containers/favourite_toggle_container';
 import { expandHashtagTimeline, clearTimeline } from '../../actions/timelines';
 import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
 import { FormattedMessage } from 'react-intl';
@@ -151,6 +152,9 @@ class HashtagTimeline extends React.PureComponent {
           multiColumn={multiColumn}
           showBackButton
         >
+          <FavouriteToggleContainer
+            tag={id}
+          />
           <ShowLocalSettingsContainer
             tag={id}
           />


### PR DESCRIPTION
#96 の改修のお気に入りタグ登録/解除ボタンを、
現ハッシュタグタイムラインに追加