### PR TITLE
Fix style for favourite_tags_controller

### DIFF
--- a/app/controllers/settings/favourite_tags_controller.rb
+++ b/app/controllers/settings/favourite_tags_controller.rb
@@ -1,10 +1,9 @@
-class Settings::FavouriteTagsController < ApplicationController
+class Settings::FavouriteTagsController < Settings::BaseController
   layout 'admin'
   before_action :authenticate_user!
   before_action :set_account
   before_action :set_favourite_tags, only: [:index, :create]
   before_action :set_favourite_tag, only: [:edit, :update, :destroy]
-  before_action :set_body_classes
 
   def index
     @favourite_tag = FavouriteTag.new(tag: Tag.new, visibility: FavouriteTag.visibilities[:public])
@@ -60,9 +59,5 @@ class Settings::FavouriteTagsController < ApplicationController
 
   def set_favourite_tags
     @favourite_tags = @account.favourite_tags.with_order.includes(:tag)
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 end

--- a/app/controllers/settings/favourite_tags_controller.rb
+++ b/app/controllers/settings/favourite_tags_controller.rb
@@ -4,6 +4,7 @@ class Settings::FavouriteTagsController < ApplicationController
   before_action :set_account
   before_action :set_favourite_tags, only: [:index, :create]
   before_action :set_favourite_tag, only: [:edit, :update, :destroy]
+  before_action :set_body_classes
 
   def index
     @favourite_tag = FavouriteTag.new(tag: Tag.new, visibility: FavouriteTag.visibilities[:public])
@@ -59,5 +60,9 @@ class Settings::FavouriteTagsController < ApplicationController
 
   def set_favourite_tags
     @favourite_tags = @account.favourite_tags.with_order.includes(:tag)
+  end
+
+  def set_body_classes
+    @body_classes = 'admin'
   end
 end

--- a/app/views/settings/favourite_tags/index.html.haml
+++ b/app/views/settings/favourite_tags/index.html.haml
@@ -4,25 +4,26 @@
 = render 'form', submit: t('favourite_tags.submit')
 %hr
 
-%table.table
-  %thead
-    %tr
-      %th= t('favourite_tags.name_of_tag')
-      %th= t('simple_form.labels.defaults.setting_default_privacy')
-      %th= t('favourite_tags.order')
-      %th= t('favourite_tags.edit_it')
-      %th= t('favourite_tags.delete_it')
-  %tbody
-    - @favourite_tags.each do |fav_tag|
+.table-wrapper
+  %table.table
+    %thead
       %tr
-        %td
-          = fa_icon 'tag'
-          = fav_tag.tag.name
-        %td
-          = I18n.t("statuses.visibilities.#{fav_tag.visibility}")
-        %td
-          = fav_tag.order
-        %td
-          = table_link_to 'edit', '', edit_settings_favourite_tag_path(fav_tag)
-        %td
-          = table_link_to 'trash', '', settings_favourite_tag_path(fav_tag), method: :delete
+        %th= t('favourite_tags.name_of_tag')
+        %th= t('simple_form.labels.defaults.setting_default_privacy')
+        %th= t('favourite_tags.order')
+        %th= t('favourite_tags.edit_it')
+        %th= t('favourite_tags.delete_it')
+    %tbody
+      - @favourite_tags.each do |fav_tag|
+        %tr
+          %td
+            = fa_icon 'tag'
+            = fav_tag.tag.name
+          %td
+            = I18n.t("statuses.visibilities.#{fav_tag.visibility}")
+          %td
+            = fav_tag.order
+          %td
+            = table_link_to 'edit', '', edit_settings_favourite_tag_path(fav_tag)
+          %td
+            = table_link_to 'trash', '', settings_favourite_tag_path(fav_tag), method: :delete


### PR DESCRIPTION
お気に入りタグのページのスタイルがおかしいのを修正。

Before
--

![before](https://user-images.githubusercontent.com/20679825/59545789-03cde100-8f5f-11e9-89fb-88bac80362a7.png)

After
--

![after](https://user-images.githubusercontent.com/20679825/59545796-0cbeb280-8f5f-11e9-97c9-d8a30c563b5b.png)
