### PR TITLE
未収載トゥートやお気に入りタグ設定のアイコンを変更

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -23,7 +23,7 @@ import Bundle from '../features/ui/components/bundle';
 
 const iconList = [
   { key: 'public', value: 'globe' },
-  { key: 'unlisted', value: 'unlock-alt' },
+  { key: 'unlisted', value: 'unlock' },
   { key: 'private', value: 'lock' },
   { key: 'direct', value: 'envelope' },
 ];

--- a/app/javascript/mastodon/features/compose/components/favourite_tags.js
+++ b/app/javascript/mastodon/features/compose/components/favourite_tags.js
@@ -14,7 +14,7 @@ const messages = defineMessages({
 
 const icons = [
   { key: 'public', icon: 'globe' },
-  { key: 'unlisted', icon: 'unlock-alt' },
+  { key: 'unlisted', icon: 'unlock' },
   { key: 'private', icon: 'lock' },
 ];
 


### PR DESCRIPTION
tootsuite#9952 で未収載アイコンが変更になっていましたので、
未収載トゥートやお気に入りタグ設定のアイコンも変更致しました。