### PR TITLE
WebUIで「このカラムに追加のハッシュタグを含める」のストリーミングが正しく動いていなかったのを修正

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/index.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.js
@@ -104,7 +104,7 @@ class HashtagTimeline extends React.PureComponent {
     const { dispatch, isLocal } = this.props;
     const { id, tags } = this.props.params;
 
-    this._subscribe(dispatch, id, tags);
+    this._subscribe(dispatch, id, isLocal, tags);
     dispatch(expandHashtagTimeline(id, { isLocal, tags }));
   }
 


### PR DESCRIPTION
Fix #240

| before | after |
| --- | --- |
| ![スクリーンショット 2020-04-28 09 57 56](https://user-images.githubusercontent.com/6533808/80435350-3befcf80-8937-11ea-800b-e3eda8fd7e5e.png) | ![image](https://user-images.githubusercontent.com/6533808/80435420-68a3e700-8937-11ea-85c8-7cb7ce3ef53b.png)|

