### PR TITLE
デフォルトタグに含まれる大文字を小文字にした

### DIFF
--- a/app/lib/friends/favourite_tags_extension.rb
+++ b/app/lib/friends/favourite_tags_extension.rb
@@ -9,9 +9,9 @@ module Friends
       DEFAULT_TAGS = [
         "デレラジ",
         "デレパ",
-        "imas_MOR",
+        "imas_mor",
         "millionradio",
-        "SideM",
+        "sidem",
       ].freeze
 
       def add_default_favourite_tag
@@ -19,7 +19,6 @@ module Friends
           self.favourite_tags.create!(visibility: 'unlisted', tag: Tag.find_or_create_by!(name: tag_name), order: (DEFAULT_TAGS.length - i))
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
新規ユーザ登録時にデフォルトで作成されるお気に入りタグと、 https://github.com/imas/mastodon/issues/247 とによって新規ユーザ登録ができなくなってしまっていたため、新規ユーザ登録時にデフォルトで作成されるお気に入りタグを一旦小文字のみに変更します