### PR TITLE
Proposal: Adjust the basis of height for collapsing status

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -9,7 +9,7 @@ import PollContainer from 'mastodon/containers/poll_container';
 import Icon from 'mastodon/components/icon';
 import { autoPlayGif } from 'mastodon/initial_state';
 
-const MAX_HEIGHT = 642; // 20px * 32 (+ 2px padding at the top)
+const MAX_HEIGHT = 322; // 20px * 16 (+ 2px padding at the top)
 
 export default class StatusContent extends React.PureComponent {
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -860,7 +860,7 @@
 }
 
 .status__content.status__content--collapsed {
-  max-height: 20px * 15; // 15 lines is roughly above 500 characters
+  max-height: 20px * 16; // 288 CJK characters (w = 18ic, h = 16lh)
 }
 
 .status__content__read-more-button {


### PR DESCRIPTION
投稿の自動折り畳み機能が欧文基準の高さで設定されているために、和文だと滅多に活用されないので挙動を調整する提案になります。

CC: @qunaud

### 変更前

<dl><dt>折り畳み判定基準</dt><dd>33 行以上</dd><dt>折り畳み後の表示行数</dt><dd>15 行（欧文でだいたい 500 文字以上になる）</dd></dl>

### 変更後

<dl><dt>折り畳み判定基準</dt><dd>17 行以上</dd><dt>折り畳み後の表示行数</dt><dd>16 行（和文で最低 288 文字程度）</dd></dl>