### PR TITLE
dependabotをセキュリティアップデートを除き無効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 0
     allow:
       - dependency-type: all
 
@@ -17,6 +17,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 0
     allow:
       - dependency-type: all


### PR DESCRIPTION
yankによりデプロイできなかったり脆弱性修正でない限りは基本的にupstreamに追従する