### PR TITLE
fix: エラー画面の画像が予期せず入れ替わる

### DIFF
--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -8,7 +8,6 @@
     = stylesheet_pack_tag 'common', media: 'all', crossorigin: 'anonymous'
     = stylesheet_pack_tag Setting.default_settings['theme'], media: 'all', crossorigin: 'anonymous'
     = javascript_pack_tag 'common', crossorigin: 'anonymous'
-    = javascript_pack_tag 'error', crossorigin: 'anonymous'
   %body.error
     .dialog
       .dialog__illustration


### PR DESCRIPTION
404 時などのエラー画面でマウスを動かすと、画像が chihiro_san.png から oops.gif に置き換えられるのを修正。

https://user-images.githubusercontent.com/20679825/156843130-508d2210-46e1-497c-8fe1-dbd12097381e.mp4


