### PR TITLE
【cherry-pick】visibilityがprivateであるstatusが誤ってタグTLのストリームに配信されていたバグを修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ jobs:
           cache-version: v1
           pkg-manager: yarn
       - run:
-          command: ./bin/rails assets:precompile
+          command: |
+            export NODE_OPTIONS=--openssl-legacy-provider
+            ./bin/rails assets:precompile
           name: Precompile assets
       - persist_to_workspace:
           paths:

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -39,10 +39,13 @@ class FanOutOnWriteService < BaseService
     notify_about_update! if update?
 
     case @status.visibility.to_sym
-    when :public, :private, :unlisted
+    when :public, :unlisted
       deliver_to_all_followers!
       deliver_to_lists!
       deliver_to_hashtag_streams_authorized_channel!
+    when :private
+      deliver_to_all_followers!
+      deliver_to_lists!
     when :limited
       deliver_to_mentioned_followers!
     else

--- a/spec/imastodon/services/fan_out_on_write_service_spec.rb
+++ b/spec/imastodon/services/fan_out_on_write_service_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe FanOutOnWriteService, type: :service do
       it_behaves_like 'tagTLのauthorizedチャンネルに配信される'
     end
 
+    context 'private' do
+      let(:visibility) { :private }
+      it_behaves_like 'LTLに配信されない'
+      it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+      it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+    end
+
+    context 'direct' do
+      let(:visibility) { :direct }
+      it_behaves_like 'LTLに配信されない'
+      it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+      it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+    end
+
     context 'メンションが含まれる投稿' do
       let(:body) { '@tachibana ヘイヘーイ。 そこのカノジョー、一緒にブラデリカしないかーい？ #hoge #fuga #nyowa' }
 
@@ -104,6 +118,20 @@ RSpec.describe FanOutOnWriteService, type: :service do
         it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
         it_behaves_like 'tagTLのauthorizedチャンネルに配信される'
       end
+
+      context 'private' do
+        let(:visibility) { :private }
+        it_behaves_like 'LTLに配信されない'
+        it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+        it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+      end
+  
+      context 'direct' do
+        let(:visibility) { :direct }
+        it_behaves_like 'LTLに配信されない'
+        it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+        it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+      end
     end
 
     context '自分以外の投稿へのin_reply_toが設定されている投稿' do
@@ -118,6 +146,20 @@ RSpec.describe FanOutOnWriteService, type: :service do
 
       context 'unlisted' do
         let(:visibility) { :unlisted }
+        it_behaves_like 'LTLに配信されない'
+        it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+        it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+      end
+
+      context 'private' do
+        let(:visibility) { :private }
+        it_behaves_like 'LTLに配信されない'
+        it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+        it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+      end
+  
+      context 'direct' do
+        let(:visibility) { :direct }
         it_behaves_like 'LTLに配信されない'
         it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
         it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
@@ -139,6 +181,20 @@ RSpec.describe FanOutOnWriteService, type: :service do
         it_behaves_like 'LTLに配信されない'
         it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
         it_behaves_like 'tagTLのauthorizedチャンネルに配信される'
+      end
+
+      context 'private' do
+        let(:visibility) { :private }
+        it_behaves_like 'LTLに配信されない'
+        it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+        it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
+      end
+  
+      context 'direct' do
+        let(:visibility) { :direct }
+        it_behaves_like 'LTLに配信されない'
+        it_behaves_like 'tagTLのunauthorizedチャンネルに配信されない'
+        it_behaves_like 'tagTLのauthorizedチャンネルに配信されない'
       end
     end
   end


### PR DESCRIPTION
https://github.com/imas/mastodon/pull/453 のcherry-pick