### PR TITLE
透過部がないPNGをJPEGに変換する独自改造の変換後拡張子をjpegに変更

### DIFF
--- a/lib/paperclip/png_converter.rb
+++ b/lib/paperclip/png_converter.rb
@@ -9,7 +9,7 @@ module Paperclip
 
       if opaque == 'true'
         basename = File.basename(file.path, File.extname(file.path))
-        dst_name = basename << ".jpg"
+        dst_name = basename << '.jpeg'
 
         dst = Paperclip::TempfileFactory.new.generate(dst_name)
 


### PR DESCRIPTION
imagemagickに起因する脆弱性を防ぐためのimagemagickポリシーに違反していた
imagemagickのポリシーを変えるよりは変換後拡張子を変えたほうがリスクは低いと判断した