### PR TITLE
Sidekiq FargateをARM64（Graviton）に切り替え

### DIFF
--- a/.ecspresso/ecs-task-def.jsonnet
+++ b/.ecspresso/ecs-task-def.jsonnet
@@ -9,6 +9,10 @@ local tfstate = std.native('tfstate');
   memory: '1024',
   executionRoleArn: tfstate('module.ecs.aws_iam_role.ecs_task_execution_role.arn'),
   taskRoleArn: tfstate('module.iam.aws_iam_role.imastodon_iam_role.arn'),
+  runtimePlatform: {
+    operatingSystemFamily: 'LINUX',
+    cpuArchitecture: 'ARM64',
+  },
 
   containerDefinitions: [
     // log_router (FireLens) - 他コンテナより先に起動する必要あり

--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- runs-onをubuntu-24.04-armに変更し、ARM64イメージをネイティブビルド
- ECSタスク定義にruntimePlatform.cpuArchitecture: ARM64を追加