### PR TITLE
build: DockerビルドキャッシュをGHA→ECRレジストリキャッシュに変更

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -41,6 +41,9 @@ jobs:
           else
             echo "image_tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
+          major=$(awk '/def major/{getline; print $0+0}' lib/mastodon/version.rb)
+          minor=$(awk '/def minor/{getline; print $0+0}' lib/mastodon/version.rb)
+          echo "cache_tag=v${major}.${minor}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,8 +54,8 @@ jobs:
           context: .
           push: true
           tags: ${{ env.ECR_REGISTRY }}/imastodon/mastodon:${{ steps.tag.outputs.image_tag }}
-          cache-from: type=gha,scope=mastodon
-          cache-to: type=gha,mode=max,scope=mastodon
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }}
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }},mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Build and push streaming
         uses: docker/build-push-action@v6
@@ -61,5 +64,5 @@ jobs:
           file: streaming/Dockerfile
           push: true
           tags: ${{ env.ECR_REGISTRY }}/imastodon/streaming:${{ steps.tag.outputs.image_tag }}
-          cache-from: type=gha,scope=streaming
-          cache-to: type=gha,mode=max,scope=streaming
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }}
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }},mode=max,image-manifest=true,oci-mediatypes=true


### PR DESCRIPTION
GHAキャッシュの10GB制限でffmpeg/libvipsの中間ステージが毎回
evictされビルドが遅くなっていた問題を修正。

- type=registry + mode=max でマルチステージ全ステージをECRに永続キャッシュ
- キャッシュタグをマイナーバージョン単位（v4.3等）で管理
- ECRのライフサイクルポリシーで最新2マイナーバージョン分を保持