### PR TITLE
AvatarOverlayIcon: sizeプロパティを実反映し公開範囲アイコンの位置ずれを修正

### DIFF
--- a/app/javascript/mastodon/components/__tests__/avatar_overlay_icon-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/avatar_overlay_icon-test.jsx
@@ -1,0 +1,38 @@
+import { fromJS } from 'immutable';
+
+import renderer from 'react-test-renderer';
+
+import AvatarOverlayIcon from '../avatar_overlay_icon';
+
+describe('<AvatarOverlayIcon>', () => {
+  const account = fromJS({
+    username: 'alice',
+    acct: 'alice',
+    display_name: 'Alice',
+    avatar: '/animated/alice.gif',
+    avatar_static: '/static/alice.jpg',
+  });
+
+  const findByClassName = (node, className) => {
+    if (!node || typeof node === 'string') return null;
+    if (node.props?.className?.split?.(' ').includes(className)) return node;
+    if (!node.children) return null;
+    for (const child of node.children) {
+      const found = findByClassName(child, className);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  it('size プロパティをコンテナとアバター画像のスタイルに反映する', () => {
+    const tree = renderer.create(
+      <AvatarOverlayIcon account={account} visibility='direct' size={40} />
+    ).toJSON();
+
+    const overlay = findByClassName(tree, 'account__avatar-overlay');
+    expect(overlay.props.style).toMatchObject({ width: 40, height: 40 });
+
+    const base = findByClassName(tree, 'account__avatar-overlay-icon-base');
+    expect(base.props.style).toMatchObject({ width: 40, height: 40 });
+  });
+});

--- a/app/javascript/mastodon/components/avatar_overlay_icon.jsx
+++ b/app/javascript/mastodon/components/avatar_overlay_icon.jsx
@@ -27,22 +27,27 @@ export default class AvatarOverlayIcon extends React.PureComponent {
     account: ImmutablePropTypes.map.isRequired,
     visibility: PropTypes.string.isRequired,
     animate: PropTypes.bool,
+    size: PropTypes.number,
   };
 
   static defaultProps = {
     animate: autoPlayGif,
+    size: 46,
   };
 
   render() {
-    const { account, visibility, animate } = this.props;
+    const { account, visibility, animate, size } = this.props;
     const icon = icons[visibility];
 
     const baseStyle = {
       backgroundImage: `url(${account.get(animate ? 'avatar' : 'avatar_static')})`,
+      width: size,
+      height: size,
+      backgroundSize: `${size}px ${size}px`,
     };
 
     return (
-      <div className='account__avatar-overlay'>
+      <div className='account__avatar-overlay' style={{ width: size, height: size }}>
         <div className='account__avatar-overlay-icon-base' style={baseStyle} />
         <Icon id={visibility} icon={icon} className='account__avatar-overlay-icon-overlay' />
       </div>


### PR DESCRIPTION
通知欄では呼び出し側が avatarSize=40 を渡すが AvatarOverlayIcon が size を無視して 46x46 ハードコードでレンダリングしていたため、
コンテナが親要素サイズ(40x40)に縮められた一方でアバター画像は 46x46
のままはみ出し、bottom:0; right:0 で配置された公開範囲アイコンが
アバター画像の右下角と一致しなくなっていた。

本家 AvatarOverlay と同じパターンで size をコンテナとアバター画像
両方に反映するよう修正する。