### PR TITLE
migrate: migration専用のecspressoタスク定義を追加

### DIFF
--- a/.ecspresso/migrate/ecs-task-def.jsonnet
+++ b/.ecspresso/migrate/ecs-task-def.jsonnet
@@ -1,0 +1,109 @@
+local must_env = std.native('must_env');
+local tfstate = std.native('tfstate');
+
+{
+  family: 'imastodon-migrate',
+  requiresCompatibilities: ['FARGATE'],
+  networkMode: 'awsvpc',
+  cpu: '512',
+  memory: '2048',
+  executionRoleArn: tfstate('module.ecs.aws_iam_role.ecs_task_execution_role.arn'),
+  taskRoleArn: tfstate('module.iam.aws_iam_role.imastodon_iam_role.arn'),
+
+  containerDefinitions: [
+    // log_router (FireLens) - migrateが終わったら一緒に落としたいのでessential=false
+    {
+      name: 'log_router',
+      image: 'public.ecr.aws/aws-observability/aws-for-fluent-bit:stable',
+      essential: false,
+      firelensConfiguration: {
+        type: 'fluentbit',
+        options: {
+          'enable-ecs-log-metadata': 'true',
+        },
+      },
+      environment: [
+        { name: 'FLB_LOG_LEVEL', value: 'warn' },
+      ],
+      logConfiguration: {
+        logDriver: 'awslogs',
+        options: {
+          'awslogs-group': '/ecs/imastodon-migrate/log_router',
+          'awslogs-region': 'us-west-2',
+          'awslogs-stream-prefix': 'log_router',
+          'awslogs-create-group': 'true',
+        },
+      },
+    },
+
+    // pgbouncer - advisory lockを正しく扱うためsessionモードで起動
+    {
+      name: 'pgbouncer',
+      image: 'public.ecr.aws/bitnami/pgbouncer:1.25.1',
+      essential: false,
+      environment: [
+        { name: 'POSTGRESQL_HOST', value: tfstate('module.rds.aws_db_instance.imastodon_rds.address') },
+        { name: 'POSTGRESQL_PORT', value: '5432' },
+        { name: 'PGBOUNCER_PORT', value: '6432' },
+        { name: 'PGBOUNCER_POOL_MODE', value: 'session' },
+        { name: 'PGBOUNCER_MAX_CLIENT_CONN', value: '20' },
+        { name: 'PGBOUNCER_DEFAULT_POOL_SIZE', value: '10' },
+        { name: 'PGBOUNCER_DATABASE', value: '*' },
+        { name: 'PGBOUNCER_SERVER_TLS_SSLMODE', value: 'require' },
+      ],
+      secrets: [
+        { name: 'POSTGRESQL_DATABASE', valueFrom: '/imastodon/prod/DB_NAME' },
+        { name: 'POSTGRESQL_USERNAME', valueFrom: '/imastodon/prod/DB_USER' },
+        { name: 'POSTGRESQL_PASSWORD', valueFrom: '/imastodon/prod/DB_PASS' },
+      ],
+      dependsOn: [
+        { containerName: 'log_router', condition: 'START' },
+      ],
+      logConfiguration: {
+        logDriver: 'awsfirelens',
+        options: {
+          Name: 'S3',
+          region: 'us-west-2',
+          bucket: tfstate('module.ecs.aws_s3_bucket.ecs_logs.bucket'),
+          's3_key_format': '/migrate-pgbouncer/%Y/%m/%d/%H/$UUID.gz',
+          'total_file_size': '100M',
+          'upload_timeout': '10m',
+          Compression: 'gzip',
+        },
+      },
+    },
+
+    // migrate - このコンテナのexit codeでtaskの最終状態が決まる
+    {
+      name: 'migrate',
+      image: tfstate('module.ecr.aws_ecr_repository.mastodon.repository_url') + ':' + must_env('IMAGE_TAG'),
+      essential: true,
+      command: ['bundle', 'exec', 'rails', 'db:migrate'],
+      environment: [
+        { name: 'RAILS_ENV', value: 'production' },
+        { name: 'DB_POOL', value: '5' },
+        { name: 'DB_HOST', value: '127.0.0.1' },
+        { name: 'DB_PORT', value: '6432' },
+        { name: 'PARAMETER_STORE_REGION', value: 'us-west-2' },
+        { name: 'PARAMETER_STORE_PREFIX', value: '/imastodon/prod/' },
+      ],
+      stopTimeout: 120,
+      dependsOn: [
+        { containerName: 'pgbouncer', condition: 'START' },
+        { containerName: 'log_router', condition: 'START' },
+      ],
+      logConfiguration: {
+        logDriver: 'awsfirelens',
+        options: {
+          Name: 'S3',
+          region: 'us-west-2',
+          bucket: tfstate('module.ecs.aws_s3_bucket.ecs_logs.bucket'),
+          's3_key_format': '/migrate/%Y/%m/%d/%H/$UUID.gz',
+          'total_file_size': '100M',
+          'upload_timeout': '10m',
+          Compression: 'gzip',
+        },
+      },
+    },
+  ],
+}

--- a/.ecspresso/migrate/ecspresso.yml
+++ b/.ecspresso/migrate/ecspresso.yml
@@ -1,0 +1,10 @@
+region: us-west-2
+cluster: imastodon_prod_cluster
+task_definition: ecs-task-def.jsonnet
+timeout: '30m'
+
+plugins:
+  - name: tfstate
+    config:
+      url: s3://imastodon-tfstate/prod.tfstate
+      region: ap-northeast-1

--- a/.github/workflows/ecspresso-run-db-migrate.yml
+++ b/.github/workflows/ecspresso-run-db-migrate.yml
@@ -50,8 +50,7 @@ jobs:
           {
             "containerOverrides": [
               {
-                "name": "sidekiq-default",
-                "command": ["bundle", "exec", "rails", "db:migrate"],
+                "name": "migrate",
                 "environment": $EXTRA_ENV
               }
             ]
@@ -61,11 +60,12 @@ jobs:
           echo "overrides=$(echo $OVERRIDES | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Run db:migrate
-        working-directory: .ecspresso/sidekiq
+        working-directory: .ecspresso/migrate
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           ecspresso run \
             --config ecspresso.yml \
             --overrides '${{ steps.overrides.outputs.overrides }}' \
+            --watch-container migrate \
             --wait-until stopped


### PR DESCRIPTION
mastodon v4.4以降のmigrationで "Failed to release advisory lock" / ConcurrentMigrationError が発生してデプロイが失敗する事象に対応する。
原因はsidekiqのtaskdefに同居する pgbouncer サイドカーが transaction モードで動作しており、PostgreSQL advisory lock のセッション境界が壊れる点にある。

migrate専用 taskdef を立て、その中の pgbouncer を session モードで 動作させる。検討した代替案と退けた理由：

- 既存taskdefのまま migration時だけ DB_HOST を RDSエンドポイントに override する案は、boot.rb の extract_env_vars が Parameter Store から読んだ値で ENV を強制上書きするため成立しない。
- pgbouncer全体を session モードに変えると、sidekiq/webapp の通常運用に おける pool容量設計が崩れるため、migration専用に閉じ込めた。

ecspresso run には --watch-container migrate を渡し、migrationコンテナ の exit code が workflow 側に伝わるようにする。