### PR TITLE
webapp: タスクCPUを1vCPU→0.5vCPUに削減

### DIFF
--- a/.ecspresso/webapp/ecs-task-def.jsonnet
+++ b/.ecspresso/webapp/ecs-task-def.jsonnet
@@ -5,7 +5,7 @@ local tfstate = std.native('tfstate');
   family: 'imastodon-webapp',
   requiresCompatibilities: ['FARGATE'],
   networkMode: 'awsvpc',
-  cpu: '1024',
+  cpu: '512',
   memory: '2048',
   executionRoleArn: tfstate('module.ecs.aws_iam_role.ecs_task_execution_role.arn'),
   taskRoleArn: tfstate('module.iam.aws_iam_role.imastodon_iam_role.arn'),


### PR DESCRIPTION
14日間の実測でCPU使用率は平均7%、時間平均の最大でも16.5%と恒常的に余剰があった。
分単位ピークの99%はタスク起動時のwarmupであり、実負荷由来のピークは65〜80%。
0.5vCPUではこの帯でスロットルするが、ALBヘルスチェックが約100秒の猶予を持ち、
CPU80%ターゲットのApp Auto Scalingで台数側に逃がせるため許容と判断した。

メモリは使用率が50%を超えているため2GBのまま据え置く。