### PR TITLE
build-and-push-ecr: イメージをARM64(Graviton)でビルドする

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -19,8 +19,12 @@ env:
   ECR_REGISTRY: 579532189334.dkr.ecr.us-west-2.amazonaws.com
 
 jobs:
-  build-and-push:
+  build_x86_64:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+      mastodon_digest: ${{ steps.build_mastodon.outputs.digest }}
+      streaming_digest: ${{ steps.build_streaming.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,21 +52,102 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push mastodon
+      - name: Build and push mastodon by digest
+        id: build_mastodon
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ env.ECR_REGISTRY }}/imastodon/mastodon:${{ steps.tag.outputs.image_tag }}
-          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }}
-          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          platforms: linux/amd64
+          outputs: type=image,name=${{ env.ECR_REGISTRY }}/imastodon/mastodon,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }}-amd64
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }}-amd64,mode=max,image-manifest=true,oci-mediatypes=true
 
-      - name: Build and push streaming
+      - name: Build and push streaming by digest
+        id: build_streaming
         uses: docker/build-push-action@v6
         with:
           context: .
           file: streaming/Dockerfile
-          push: true
-          tags: ${{ env.ECR_REGISTRY }}/imastodon/streaming:${{ steps.tag.outputs.image_tag }}
-          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }}
-          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          platforms: linux/amd64
+          outputs: type=image,name=${{ env.ECR_REGISTRY }}/imastodon/streaming,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }}-amd64
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }}-amd64,mode=max,image-manifest=true,oci-mediatypes=true
+
+  build_arm64:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      mastodon_digest: ${{ steps.build_mastodon.outputs.digest }}
+      streaming_digest: ${{ steps.build_streaming.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::579532189334:role/mastodon_deployer
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          major=$(awk '/def major/{getline; print $0+0}' lib/mastodon/version.rb)
+          minor=$(awk '/def minor/{getline; print $0+0}' lib/mastodon/version.rb)
+          echo "cache_tag=v${major}.${minor}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push mastodon by digest
+        id: build_mastodon
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64/v8
+          outputs: type=image,name=${{ env.ECR_REGISTRY }}/imastodon/mastodon,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }}-arm64
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/mastodon-cache:${{ steps.tag.outputs.cache_tag }}-arm64,mode=max,image-manifest=true,oci-mediatypes=true
+
+      - name: Build and push streaming by digest
+        id: build_streaming
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: streaming/Dockerfile
+          platforms: linux/arm64/v8
+          outputs: type=image,name=${{ env.ECR_REGISTRY }}/imastodon/streaming,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }}-arm64
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/imastodon/streaming-cache:${{ steps.tag.outputs.cache_tag }}-arm64,mode=max,image-manifest=true,oci-mediatypes=true
+
+  build_manifest:
+    runs-on: ubuntu-latest
+    needs:
+      - build_x86_64
+      - build_arm64
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::579532189334:role/mastodon_deployer
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create and push manifests
+        env:
+          IMAGE_TAG: ${{ needs.build_x86_64.outputs.image_tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.ECR_REGISTRY }}/imastodon/mastodon:${IMAGE_TAG} \
+            '${{ env.ECR_REGISTRY }}/imastodon/mastodon@${{ needs.build_x86_64.outputs.mastodon_digest }}' \
+            '${{ env.ECR_REGISTRY }}/imastodon/mastodon@${{ needs.build_arm64.outputs.mastodon_digest }}'
+          docker buildx imagetools create \
+            --tag ${{ env.ECR_REGISTRY }}/imastodon/streaming:${IMAGE_TAG} \
+            '${{ env.ECR_REGISTRY }}/imastodon/streaming@${{ needs.build_x86_64.outputs.streaming_digest }}' \
+            '${{ env.ECR_REGISTRY }}/imastodon/streaming@${{ needs.build_arm64.outputs.streaming_digest }}'


### PR DESCRIPTION
Fargateのarm64は同一vCPU数でx86比約20%安い。webappの0.5vCPU化を1週間観察した 結果、CPUを削る方向はレイテンシとのトレードオフが大きいと分かったため、
コスト削減は単価を下げる方向で取る。

ARM64化は2026-03-15にPR #511(imastodon)/#510(v4.3)で一度入れたが、 当時使っていたbitnami/pgbouncerにarm64ビルドが無く同日中にPR #513/#512で revertした。現在はedoburu/pgbouncer:v1.25.1-p0に差し替わっておりlinux/arm64を 持つ。aws-for-fluent-bit:stableも同様。当時の阻害要因は解消している。

runs-onをubuntu-24.04-armにしてネイティブビルドする。QEMUエミュレーションは Rubyのネイティブ拡張とyarnのビルドで極端に遅くなるため採用しない。

当時併せて疑われたmanifest indexのvariant: v8欠落については、実際にFargateで 稼働しているaws-for-fluent-bitとedoburu/pgbouncerのどちらもdescriptorが variant無しのlinux/arm64であることを確認したため、push-by-digestと
imagetools createによる作り直しは不要と判断した。

タスク定義側のruntimePlatform指定はimastodonブランチで別途行う。
イメージがarm64でpushされるより先にタスク定義を反映するとタスクが起動しないため、
このビルド変更を先に入れる必要がある。


Claude-Session: https://claude.ai/code/session_014DX1ChKk8nn8rGGnoyDnzj