### PR TITLE
折りたたみsystem specをFoldableの現行実装に追従させる

### DIFF
--- a/spec/imastodon/system/advanced_ui_spec.rb
+++ b/spec/imastodon/system/advanced_ui_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe 'マルチカラムUI', :js, type: :system do
       end
 
       it '折りたたみボタンで開閉できる' do
-        foldable = find('.compose__extra .scrollable.optionally-scrollable')
+        expect(page).to have_css('.compose__extra .foldable--visible')
         within('.compose__extra__header__fold__icon') { click_button }
-        expect(foldable['style']).to include('height: 0px')
+        expect(page).to have_no_css('.compose__extra .foldable--visible')
         within('.compose__extra__header__fold__icon') { click_button }
-        expect(foldable['style']).to_not include('height: 0px')
+        expect(page).to have_css('.compose__extra .foldable--visible')
       end
     end
 

--- a/spec/imastodon/system/favourite_tags_spec.rb
+++ b/spec/imastodon/system/favourite_tags_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe 'お気に入りタグ', :js, type: :system do
     end
 
     it '折りたたみボタンで開閉できる' do
-      foldable = find('.compose__extra .scrollable.optionally-scrollable')
+      expect(page).to have_css('.compose__extra .foldable--visible')
       within('.compose__extra__header__fold__icon') { click_button }
-      expect(foldable['style']).to include('height: 0px')
+      expect(page).to have_no_css('.compose__extra .foldable--visible')
       within('.compose__extra__header__fold__icon') { click_button }
-      expect(foldable['style']).to_not include('height: 0px')
+      expect(page).to have_css('.compose__extra .foldable--visible')
     end
   end
 


### PR DESCRIPTION
Foldableはインラインstyleでheightを操作する実装からgrid-template-rowsを CSSクラスで切り替える実装に変わっており、specが参照していた
.scrollable.optionally-scrollable要素もstyle属性も存在しなくなっていた。

開閉状態はfoldable--visibleクラスの有無が単一の情報源なので、これを直接
検証する。トランジション中の計算値を見るとflakyになるため採用しない。